### PR TITLE
Allow API_ROOT selection via ENV variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+LABSTEP_API='testing'

--- a/labstep/config.py
+++ b/labstep/config.py
@@ -1,4 +1,15 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-API_ROOT = 'https://api.labstep.com/'
+import os
+from dotenv import load_dotenv
+load_dotenv()
+
+API = os.getenv('LABSTEP_API')
+
+if API == 'testing':
+    API_ROOT = 'https://api-testing.labstep.com/'
+elif API == 'staging':
+    API_ROOT = 'https://api-staging.labstep.com/'
+else:
+    API_ROOT = 'https://api.labstep.com/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Pylama
 sphinxcontrib-programoutput
 labstep
 pandas
+python-dotenv

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 setup(name='labstep',
-      version='2.0.3',
+      version='2.0.2',
       description='Python SDK for working with the Labstep API',
       long_description=long_description,
       url='http://github.com/Labstep/labstepPy',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 setup(name='labstep',
-      version='2.0.1',
+      version='2.0.3',
       description='Python SDK for working with the Labstep API',
       long_description=long_description,
       url='http://github.com/Labstep/labstepPy',
@@ -12,6 +12,6 @@ setup(name='labstep',
       author_email='barney@labstep.com',
       license='MIT',
       packages=['labstep'],
-      install_requires=['requests'],
+      install_requires=['requests', 'python-dotenv'],
       tests_require=["pytest"],
       zip_safe=False)

--- a/tests/test_resource_location.py
+++ b/tests/test_resource_location.py
@@ -12,13 +12,15 @@ testName = labstep.helpers.getTime()
 class TestResourceLocation:
     def test_edit(self):
         entity = testUser.newResourceLocation(testName)
-        result = entity.edit('Pytest Edited')
+        newName = labstep.helpers.getTime()
+        result = entity.edit(newName)
         result.delete()
-        assert result.name == 'Pytest Edited', \
+        assert result.name == newName, \
             'FAILED TO EDIT RESOURCE LOCATION'
 
     def test_delete(self):
-        entityToDelete = testUser.newResourceLocation('testDelete')
+        testName = labstep.helpers.getTime()
+        entityToDelete = testUser.newResourceLocation(testName)
         result = entityToDelete.delete()
         assert result is None, \
             'FAILED TO DELETE RESOURCE LOCATION'

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -12,13 +12,15 @@ testName = labstep.helpers.getTime()
 class TestTag:
     def test_edit(self):
         entity = testUser.newTag(testName, 'experiment_workflow')
-        result = entity.edit('Pytest Edited')
+        newName = labstep.helpers.getTime()
+        result = entity.edit(newName)
         result.delete()
-        assert result.name == 'Pytest Edited', \
+        assert result.name == newName, \
             'FAILED TO EDIT TAG NAME'
 
     def test_delete(self):
-        entityToDelete = testUser.newTag('testDelete', 'experiment_workflow')
+        testName = labstep.helpers.getTime()
+        entityToDelete = testUser.newTag(testName, 'experiment_workflow')
         result = entityToDelete.delete()
         assert result is None, \
             'FAILED TO DELETE TAG'


### PR DESCRIPTION
- ENV variable called LABSTEP_API sets the API_ROOT used.
- If not already set it looks for it in .env file.
- If no .env file found (as will be the case if downloaded via PyPi) it defaults to production