### PR TITLE
Refactor methods to use id

### DIFF
--- a/labstep/comment.py
+++ b/labstep/comment.py
@@ -19,12 +19,13 @@ def getComments(entity, count=100, extraParams={}):
     comments
         List of the comments attached.
     """
-    filterParams = {'parent_thread_id': entity.thread['id'], 'search': None}
-    params = {**filterParams, **extraParams}
+    params = {'parent_thread_id': entity.thread['id'],
+              'search': None,
+              **extraParams}
     return getEntities(entity.__user__, Comment, count, params)
 
 
-def addComment(entity, body, file=None, extraParams={}):
+def addComment(entity, body, file_id=None, extraParams={}):
     """
     Add a comment to a Labstep entity such as an Experiment or Resource.
 
@@ -46,14 +47,11 @@ def addComment(entity, body, file=None, extraParams={}):
     """
     threadId = entity.thread['id']
 
-    filterParams = {'body': body,
-                    'parent_thread_id': threadId,
-                    }
+    params = {'body': body,
+              'parent_thread_id': threadId,
+              'file_id': file_id,
+              **extraParams}
 
-    if file is not None:
-        filterParams['file_id'] = [file.id]
-
-    params = {**filterParams, **extraParams}
     return newEntity(entity.__user__, Comment, params)
 
 
@@ -72,10 +70,10 @@ def addCommentWithFile(entity, body, filepath, extraParams={}):
         A Labstep File entity to attach to the comment.
     """
     if filepath is not None:
-        lsFile = newFile(entity.__user__, filepath)
+        file_id = newFile(entity.__user__, filepath).id
     else:
-        lsFile = None
-    return addComment(entity, body, lsFile, extraParams=extraParams)
+        file_id = None
+    return addComment(entity, body, file_id=file_id, extraParams=extraParams)
 
 
 def editComment(comment, body, extraParams={}):
@@ -94,8 +92,7 @@ def editComment(comment, body, extraParams={}):
     comment
         An object representing the edited comment.
     """
-    filterParams = {'body': body}
-    params = {**filterParams, **extraParams}
+    params = {'body': body, **extraParams}
     return editEntity(comment, params)
 
 

--- a/labstep/experiment.py
+++ b/labstep/experiment.py
@@ -912,4 +912,7 @@ class Experiment(PrimaryEntity):
                   'units': units,
                   **extraParams}
 
+        if params['value'] is not None:
+            params['value'] = str(params['value'])
+
         return newEntity(self.__user__, ExperimentMaterial, params)

--- a/labstep/experiment.py
+++ b/labstep/experiment.py
@@ -213,7 +213,7 @@ class ExperimentProtocol(Entity):
         materials = self.experiment_values
         return listToClass(materials, ExperimentMaterial, self.__user__)
 
-    def addMaterial(self, name=None, amount=None, units=None, resource=None, resource_item=None,
+    def addMaterial(self, name=None, amount=None, units=None, resource_id=None, resource_item_id=None,
                     extraParams={}):
         """
         Add a new material to the ExperimentProtocol.
@@ -226,10 +226,10 @@ class ExperimentProtocol(Entity):
             The amount used.
         units (str)
             The units for the amount.
-        resource (Resource)
-            The :class:`~labstep.resource.Resource` used.
-        resource_item (ResourceItem)
-            The specific :class:`~labstep.resource.ResourceItem` used.
+        resource_id (int)
+            The id of the :class:`~labstep.resource.Resource` used.
+        resource_item_id (ResourceItem)
+            The id of the specific :class:`~labstep.resource.ResourceItem` used.
 
         Returns
         -------
@@ -243,22 +243,19 @@ class ExperimentProtocol(Entity):
             experiment = user.getExperiment(17000)
             resource = user.getResources(search_query='Sample A')[0]
             experiment.addMaterial(name='Sample A', amount='2', units='ml',
-                                 resource=resource)
+                                 resource_id=resource.id)
         """
-        if amount is not None:
-            amount = str(amount)
+        params = {'experiment_id': self.id,
+                  'name': name,
+                  'resource_id': resource_id,
+                  'resource_item_id': resource_item_id,
+                  'value': amount,
+                  'units': units,
+                  **extraParams}
 
-        filterParams = {'experiment_id': self.id,
-                        'name': name,
-                        'value': amount,
-                        'units': units}
+        if params['value'] is not None:
+            params['value'] = str(params['value'])
 
-        if resource is not None:
-            filterParams['resource_id'] = resource.id
-        if resource_item is not None:
-            filterParams['resource_item_id'] = resource_item.id
-
-        params = {**filterParams, **extraParams}
         return newEntity(self.__user__, ExperimentMaterial, params)
 
     def getSteps(self):
@@ -406,10 +403,10 @@ class ExperimentMaterial(Entity):
             The amount of the Experiment Material.
         units (str)
             The units of the amount.
-        resource (Resource)
+        resource_id (int)
             The :class:`~labstep.resource.Resource` of the Experiment Material.
-        resourceItem (ResourceItem)
-            The :class:`~labstep.resource.ResourceItem` of the Experiment Material.
+        resource_item_id (int)
+            The id of the :class:`~labstep.resource.ResourceItem` of the Experiment Material.
 
         Returns
         -------

--- a/labstep/experiment.py
+++ b/labstep/experiment.py
@@ -62,11 +62,11 @@ def getExperiments(user, count=100, search_query=None,
     List[:class:`~labstep.experiment.Experiment`]
         A list of Experiment objects.
     """
-    filterParams = {'search_query': search_query,
-                    'created_at_from': createdAtFrom(created_at_from),
-                    'created_at_to': createdAtTo(created_at_to),
-                    'tag_id': tag_id}
-    params = {**filterParams, **extraParams}
+    params = {'search_query': search_query,
+              'created_at_from': createdAtFrom(created_at_from),
+              'created_at_to': createdAtTo(created_at_to),
+              'tag_id': tag_id,
+              **extraParams}
     return getEntities(user, Experiment, count, params)
 
 
@@ -89,9 +89,9 @@ def newExperiment(user, name, description=None, extraParams={}):
     experiment
         An object representing the new Labstep Experiment.
     """
-    filterParams = {'name': name,
-                    'description': description}
-    params = {**filterParams, **extraParams}
+    params = {'name': name,
+              'description': description,
+              **extraParams}
     return newEntity(user, Experiment, params)
 
 
@@ -118,12 +118,11 @@ def editExperiment(experiment, name=None, description=None, started_at=None,
     experiment
         An object representing the edited Experiment.
     """
-    filterParams = {'name': name,
-                    'description': description,
-                    'started_at': handleDate(started_at),
-                    'deleted_at': deleted_at,
-                    }
-    params = {**filterParams, **extraParams}
+    params = {'name': name,
+              'description': description,
+              'started_at': handleDate(started_at),
+              'deleted_at': deleted_at,
+              **extraParams}
     return editEntity(experiment, params)
 
 
@@ -144,9 +143,9 @@ def addProtocolToExperiment(experiment, protocol):
     experiment_protocol
         An object representing the Protocol attached to the Experiment.
     """
-    fields = {'experiment_workflow_id': experiment.id,
+    params = {'experiment_workflow_id': experiment.id,
               'protocol_id': protocol.last_version['id']}
-    return newEntity(experiment.__user__, ExperimentProtocol, fields)
+    return newEntity(experiment.__user__, ExperimentProtocol, params)
 
 
 class ExperimentProtocol(Entity):
@@ -301,7 +300,7 @@ class ExperimentProtocol(Entity):
 class ExperimentMaterial(Entity):
     __entityName__ = 'experiment-value'
 
-    def edit(self, amount=None, units=None, resource=None, resourceItem=None):
+    def edit(self, amount=None, units=None, resource_id=None, resource_item_id=None):
         """
         Edit an existing Experiment Material.
 
@@ -330,14 +329,13 @@ class ExperimentMaterial(Entity):
             exp_protocol_materials = exp_protocol.getMaterials()
             exp_protocol_materials[0].edit(amount=1.7, units='ml')
         """
-        fields = {'value': amount,
-                  'units': units}
-        if resource is not None:
-            fields['resource_id'] = resource.id
-        if resourceItem is not None:
-            fields['resource_item_id'] = resourceItem.id
+        params = {'value': amount,
+                  'units': units,
+                  'resource_id': resource_id,
+                  'resource_item_id': resource_item_id
+                  }
 
-        return editEntity(self, fields)
+        return editEntity(self, params)
 
 
 class ExperimentStep(Entity):
@@ -357,8 +355,8 @@ class ExperimentStep(Entity):
         :class:`~labstep.experiment.ExperimentStep`
             An object representing the edited Experiment Step.
         """
-        fields = {'ended_at': completed_at}
-        return editEntity(self, fields)
+        params = {'ended_at': completed_at}
+        return editEntity(self, params)
 
     def complete(self):
         """
@@ -477,8 +475,8 @@ class ExperimentTable(Entity):
             }
             exp_protocol_tables[0].edit(data=data)
         """
-        fields = {'data': data}
-        return editEntity(self, fields)
+        params = {'data': data}
+        return editEntity(self, params)
 
 
 class ExperimentTimer(Entity):
@@ -751,9 +749,9 @@ class Experiment(PrimaryEntity):
         :class:`~labstep.experiment.ExperimentSignature`
             The signature that has been added
         """
-        fields = {
+        params = {
             "statement": statement,
             "is_lock": int(lock),
             "experiment_workflow_id": self.id
         }
-        return newEntity(self.__user__, ExperimentSignature, fields)
+        return newEntity(self.__user__, ExperimentSignature, params)

--- a/labstep/file.py
+++ b/labstep/file.py
@@ -27,8 +27,7 @@ def newFile(user, filepath, extraParams={}):
         An object representing the uploaded file to Labstep.
     """
     files = {'file': open(filepath, 'rb')}
-    filterParams = {'group_id': user.activeWorkspace}
-    params = {**filterParams, **extraParams}
+    params = {'group_id': user.activeWorkspace, **extraParams}
     headers = getHeaders(user)
     url = url_join(API_ROOT, "/api/generic/file/upload")
     r = requests.post(url, headers=headers, files=files, data=params)
@@ -96,9 +95,9 @@ def getFiles(user, count=100, search_query=None, file_type=None,
 
             entities = user.getFiles(search_query='bacteria')
         """
-    filterParams = {'search_query': search_query,
-                    'filetype': file_type}
-    params = {**filterParams, **extraParams}
+    params = {'search_query': search_query,
+              'filetype': file_type,
+              **extraParams}
     return getEntities(user, File, count, params)
 
 

--- a/labstep/metadata.py
+++ b/labstep/metadata.py
@@ -59,14 +59,14 @@ def addMetadataTo(entity, fieldName, fieldType="default",
     metadata
         An object representing the new Labstep Metadata.
     """
-    filterParams = {'metadata_thread_id': entity.metadata_thread['id'],
-                    'type': fieldType,
-                    'label': fieldName,
-                    'value': value,
-                    'date': handleDate(date),
-                    'number': number,
-                    'unit': unit}
-    params = {**filterParams, **extraParams}
+    params = {'metadata_thread_id': entity.metadata_thread['id'],
+              'type': fieldType,
+              'label': fieldName,
+              'value': value,
+              'date': handleDate(date),
+              'number': number,
+              'unit': unit,
+              **extraParams}
     return newEntity(entity.__user__, Metadata, params)
 
 
@@ -88,30 +88,9 @@ def editMetadata(metadata, fieldName=None, value=None, extraParams={}):
     metadata
         An object representing the edited Metadata.
     """
-    filterParams = {'label': fieldName,
-                    'value': value}
-    params = {**filterParams, **extraParams}
+    params = {'label': fieldName,
+              'value': value, **extraParams}
     return editEntity(metadata, params)
-
-
-def deleteMetadata(metadata):
-    """
-    Delete an existing Metadata.
-
-    Parameters
-    ----------
-    metadata (obj)
-        The Metadata to delete.
-
-    Returns
-    -------
-    None
-    """
-    headers = getHeaders(metadata.__user__)
-    url = url_join(API_ROOT, "/api/generic/metadata/", str(metadata.id))
-    r = requests.delete(url, headers=headers)
-    handleError(r)
-    return None
 
 
 class Metadata(Entity):
@@ -155,12 +134,21 @@ class Metadata(Entity):
 
     def delete(self):
         """
-        Delete an existing Metadata field.
+        Delete an existing Metadata.
 
-        Example
+        Parameters
+        ----------
+        metadata (obj)
+            The Metadata to delete.
+
+        Returns
         -------
-        ::
-
-            metadata.delete()
+        None
         """
-        return deleteMetadata(self)
+        headers = getHeaders(self.__user__)
+        url = url_join(API_ROOT, "/api/generic/",
+                       Metadata.__entityName__,
+                       str(self.id))
+        r = requests.delete(url, headers=headers)
+        handleError(r)
+        return None

--- a/labstep/orderRequest.py
+++ b/labstep/orderRequest.py
@@ -51,15 +51,14 @@ def getOrderRequests(user, count=100, search_query=None, tag_id=None, status=Non
     OrderRequests
         A list of OrderRequest objects.
     """
-    filterParams = {'search_query': search_query,
-                    'tag_id': tag_id,
-                    'status': handleString(status)
-                    }
-    params = {**filterParams, **extraParams}
+    params = {'search_query': search_query,
+              'tag_id': tag_id,
+              'status': handleString(status),
+              **extraParams}
     return getEntities(user, OrderRequest, count, params)
 
 
-def newOrderRequest(user, resource, quantity=1, extraParams={}):
+def newOrderRequest(user, resource_id=None, quantity=1, extraParams={}):
     """
     Create a new Labstep OrderRequest.
 
@@ -68,8 +67,8 @@ def newOrderRequest(user, resource, quantity=1, extraParams={}):
     user (obj)
         The Labstep user creating the OrderRequest.
         Must have property 'api_key'. See 'login'.
-    resource (obj)
-        The Labstep Resource.
+    resource_id (obj)
+        The id of the Labstep Resource being requested.
     quantity (int)
         The quantity of the new OrderRequest.
 
@@ -78,13 +77,13 @@ def newOrderRequest(user, resource, quantity=1, extraParams={}):
     OrderRequest
         An object representing the new Labstep OrderRequest.
     """
-    filterParams = {'resource_id': resource.id,
-                    'quantity': quantity}
-    params = {**filterParams, **extraParams}
+    params = {'resource_id': resource_id,
+              'quantity': quantity,
+              **extraParams}
     return newEntity(user, OrderRequest, params)
 
 
-def editOrderRequest(orderRequest, status=None, resource=None, quantity=None,
+def editOrderRequest(orderRequest, status=None, resource_id=None, quantity=None,
                      price=None, currency=None, deleted_at=None, extraParams={}):
     """
     Edit an existing OrderRequest.
@@ -96,8 +95,8 @@ def editOrderRequest(orderRequest, status=None, resource=None, quantity=None,
     status (str)
         The status of the OrderRequest. Options are: "new", "approved",
         "ordered", "back_ordered", "received", and "cancelled".
-    resource (obj)
-        The Resource of the OrderRequest.
+    resource_id (obj)
+        The id of the Resource being requested.
     quantity (int)
         The quantity of the OrderRequest.
     price (int)
@@ -114,15 +113,14 @@ def editOrderRequest(orderRequest, status=None, resource=None, quantity=None,
     OrderRequest
         An object representing the edited OrderRequest.
     """
-    filterParams = {'status': handleString(status),
-                    'quantity': quantity,
-                    'price': price,
-                    'currency': currency,
-                    'deleted_at': deleted_at}
-    if resource is not None:
-        filterParams['resource_id'] = resource.id
+    params = {'status': handleString(status),
+              'resource_id': resource_id,
+              'quantity': quantity,
+              'price': price,
+              'currency': currency,
+              'deleted_at': deleted_at,
+              **extraParams}
 
-    params = {**filterParams, **extraParams}
     return editEntity(orderRequest, params)
 
 
@@ -141,7 +139,7 @@ class OrderRequest(PrimaryEntity):
     """
     __entityName__ = 'order-request'
 
-    def edit(self, status=None, resource=None, quantity=None,
+    def edit(self, status=None, resource_id=None, quantity=None,
              price=None, currency=None, extraParams={}):
         """
         Edit an existing OrderRequest.
@@ -151,8 +149,8 @@ class OrderRequest(PrimaryEntity):
         status (str)
             The status of the OrderRequest. Options are: "new", "approved",
             "ordered", "back_ordered", "received", and "cancelled".
-        resource (Resource)
-            The :class:`~labstep.resource.Resource` of the OrderRequest.
+        resource_id (Resource)
+            The id of the :class:`~labstep.resource.Resource` being requested.
         quantity (int)
             The quantity of the OrderRequest.
         price (int)
@@ -175,8 +173,8 @@ class OrderRequest(PrimaryEntity):
             my_orderRequest.edit(status="back_ordered", quantity=3,
                                  price=50, currency="GBP")
         """
-        return editOrderRequest(self, status, resource, quantity,
-                                price, currency, extraParams=extraParams)
+        return editOrderRequest(self, status=status, resource_id=resource_id, quantity=quantity,
+                                price=price, currency=currency, extraParams=extraParams)
 
     def delete(self):
         """

--- a/labstep/permissions.py
+++ b/labstep/permissions.py
@@ -28,14 +28,14 @@ def newPermission(entity, workspace_id, permission):
     headers = getHeaders(entity.__user__)
     url = url_join(API_ROOT, "api/generic/", 'acl')
 
-    fields = {
+    params = {
         'id': entity.id,
         'entity_class': entityName.replace('-', '_'),
         'action': 'grant',
         'group_id': workspace_id,
         'permission': permission
     }
-    r = requests.post(url, headers=headers, json=fields)
+    r = requests.post(url, headers=headers, json=params)
     handleError(r)
     return entity
 
@@ -64,7 +64,7 @@ def editPermission(entity, workspace_id, permission):
     headers = getHeaders(entity.__user__)
     url = url_join(API_ROOT, "api/generic/", 'acl')
 
-    fields = {
+    params = {
         'id': entity.id,
         'entity_class': entityName.replace('-', '_'),
         'action': 'set',
@@ -72,7 +72,7 @@ def editPermission(entity, workspace_id, permission):
         'group_owner_id': workspace_id,
         'permission': permission
     }
-    r = requests.post(url, headers=headers, json=fields)
+    r = requests.post(url, headers=headers, json=params)
     handleError(r)
     return entity
 
@@ -99,13 +99,13 @@ def revokePermission(entity, workspace_id):
     headers = getHeaders(entity.__user__)
     url = url_join(API_ROOT, "api/generic/", 'acl')
 
-    fields = {
+    params = {
         'id': entity.id,
         'entity_class': entityName.replace('-', '_'),
         'action': 'revoke',
         'group_id': workspace_id
     }
-    r = requests.post(url, headers=headers, json=fields)
+    r = requests.post(url, headers=headers, json=params)
     handleError(r)
     return entity
 
@@ -156,8 +156,8 @@ def transferOwnership(entity, workspace_id):
     headers = getHeaders(entity.__user__)
     url = url_join(API_ROOT, "api/generic/", entityName,
                    str(entity.id), 'transfer-ownership')
-    fields = {'group_id': workspace_id}
-    r = requests.post(url, headers=headers, json=fields)
+    params = {'group_id': workspace_id}
+    r = requests.post(url, headers=headers, json=params)
     handleError(r)
     return
 

--- a/labstep/protocol.py
+++ b/labstep/protocol.py
@@ -419,8 +419,8 @@ class Protocol(PrimaryEntity):
             The amount required by the protocol.
         units (str)
             The units for the amount.
-        resource (Resource)
-            The specific :class:`~labstep.resource.Resource` recommended for
+        resource_id (int)
+            The id of the :class:`~labstep.resource.Resource` recommended for
             use with the protocol.
 
         Returns
@@ -435,7 +435,7 @@ class Protocol(PrimaryEntity):
             protocol = user.getProtocol(17000)
             resource = user.getResources(search_query='Sample A')[0]
             protocol.addMaterial(name='Sample A', amount='2', units='ml',
-                                 resource=resource)
+                                 resource_id=resource.id)
         """
         params = {'protocol_id': self.last_version['id'],
                   'resource_id': resource_id,
@@ -444,8 +444,8 @@ class Protocol(PrimaryEntity):
                   'units': units,
                   **extraParams}
 
-        if params['amount'] is not None:
-            params['amount'] = str(params['amount'])
+        if params['value'] is not None:
+            params['value'] = str(params['value'])
 
         return newEntity(self.__user__, ProtocolMaterial, params)
 

--- a/labstep/resource.py
+++ b/labstep/resource.py
@@ -54,9 +54,9 @@ def getResources(user, count=100, search_query=None, tag_id=None,
     resources
         A list of Resource objects.
     """
-    filterParams = {'search_query': search_query,
-                    'tag_id': tag_id}
-    params = {**filterParams, **extraParams}
+    params = {'search_query': search_query,
+              'tag_id': tag_id, 
+              **extraParams}
     return getEntities(user, Resource, count, params)
 
 
@@ -77,12 +77,12 @@ def newResource(user, name, extraParams={}):
     resource
         An object representing the new Labstep Resource.
     """
-    filterParams = {'name': name}
-    params = {**filterParams, **extraParams}
+    params = {'name': name, **extraParams}
     return newEntity(user, Resource, params)
 
 
-def editResource(resource, name=None, deleted_at=None, resource_category=None,
+def editResource(resource, name=None, deleted_at=None,
+                 resource_category_id=None,
                  extraParams={}):
     """
     Edit an existing Resource.
@@ -95,21 +95,18 @@ def editResource(resource, name=None, deleted_at=None, resource_category=None,
         The new name of the Experiment.
     deleted_at (str)
         The timestamp at which the Resource is deleted/archived.
-    resource_category (obj)
-        The ResourceCategory to add to a Resource.
+    resource_category_id (obj)
+        The id of the ResourceCategory to add to a Resource.
 
     Returns
     -------
     resource
         An object representing the edited Resource.
     """
-    filterParams = {'name': name,
-                    'deleted_at': deleted_at}
-
-    if resource_category is not None:
-        filterParams['resource_category_id'] = resource_category.id
-
-    params = {**filterParams, **extraParams}
+    params = {'name': name,
+              'resource_category_id': resource_category_id,
+              'deleted_at': deleted_at,
+              **extraParams}
     return editEntity(resource, params)
 
 
@@ -201,8 +198,8 @@ class Resource(PrimaryEntity):
             metadata = resource.addMetadata("Refractive Index",
                                                value="1.73")
         """
-        return addMetadataTo(self, fieldName, fieldType, value, date,
-                             number, unit,
+        return addMetadataTo(self, fieldName=fieldName, fieldType=fieldType, value=value, date=date,
+                             number=number, unit=unit,
                              extraParams=extraParams)
 
     def getMetadata(self):
@@ -224,15 +221,15 @@ class Resource(PrimaryEntity):
         """
         return getMetadata(self)
 
-    def setResourceCategory(self, resource_category, extraParams={}):
+    def setResourceCategory(self, resource_category_id, extraParams={}):
         """
         Add a Labstep ResourceCategory to a Resource.
 
         Parameters
         ----------
-        resource_category (ResourceCategory)
-            The :class:`~labstep.resourceCategory.ResourceCategory` to add
-            to the Resource.
+        resource_category_id (int)
+            The id of :class:`~labstep.resourceCategory.ResourceCategory` to set for
+            the Resource.
 
         Returns
         -------
@@ -247,9 +244,9 @@ class Resource(PrimaryEntity):
             resource_category = user.getResourceCategory(170)
 
             # Set the Resource Category
-            my_resource = my_resource.setResourceCategory(resource_category)
+            my_resource = my_resource.setResourceCategory(resource_category.id)
         """
-        return editResource(self, resource_category=resource_category,
+        return editResource(self, resource_category_id=resource_category_id,
                             extraParams=extraParams)
 
     def newOrderRequest(self, quantity=1, extraParams={}):
@@ -307,7 +304,7 @@ class Resource(PrimaryEntity):
 
     def newItem(self, name=None, availability='available',
                 quantity_amount=None, quantity_unit=None,
-                location=None, extraParams={}):
+                resource_location_id=None, extraParams={}):
         """
         Create a new Labstep ResourceItem.
 
@@ -322,8 +319,8 @@ class Resource(PrimaryEntity):
             The quantity of the ResourceItem.
         quantity_unit (str)
             The unit of the quantity.
-        location (obj)
-            The ResourceLocation of the ResourceItem.
+        resource_location_id (int)
+            The id of the ResourceLocation of the ResourceItem.
 
         Returns
         -------
@@ -337,7 +334,11 @@ class Resource(PrimaryEntity):
             my_resource = user.getResource(17000)
             item = my_resource.newItem(name='Test Item')
         """
-        return newResourceItem(self.__user__, self, name,
-                               availability, quantity_amount,
-                               quantity_unit, location,
+        return newResourceItem(self.__user__,
+                               name=name,
+                               resource_id=self.id,
+                               availability=availability,
+                               quantity_amount=quantity_amount,
+                               quantity_unit=quantity_unit,
+                               resource_location_id=resource_location_id,
                                extraParams=extraParams)

--- a/labstep/resource.py
+++ b/labstep/resource.py
@@ -274,7 +274,9 @@ class Resource(PrimaryEntity):
             my_resource = user.getResource(17000)
             order_request = my_resource.newOrderRequest(quantity=2)
         """
-        return newOrderRequest(self.__user__, self, quantity,
+        return newOrderRequest(self.__user__,
+                               resource_id=self.id,
+                               quantity=quantity,
                                extraParams=extraParams)
 
     def getItems(self, count=100, search_query=None, extraParams={}):

--- a/labstep/resource.py
+++ b/labstep/resource.py
@@ -304,7 +304,9 @@ class Resource(PrimaryEntity):
             my_resource = user.getResource(17000)
             items = my_resource.getItems()
         """
-        return getResourceItems(self.__user__, self, count=count,
+        return getResourceItems(self.__user__,
+                                resource_id=self.id,
+                                count=count,
                                 search_query=search_query,
                                 extraParams=extraParams)
 

--- a/labstep/resource.py
+++ b/labstep/resource.py
@@ -55,7 +55,7 @@ def getResources(user, count=100, search_query=None, tag_id=None,
         A list of Resource objects.
     """
     params = {'search_query': search_query,
-              'tag_id': tag_id, 
+              'tag_id': tag_id,
               **extraParams}
     return getEntities(user, Resource, count, params)
 
@@ -198,7 +198,10 @@ class Resource(PrimaryEntity):
             metadata = resource.addMetadata("Refractive Index",
                                                value="1.73")
         """
-        return addMetadataTo(self, fieldName=fieldName, fieldType=fieldType, value=value, date=date,
+        return addMetadataTo(self,
+                             fieldName=fieldName,
+                             fieldType=fieldType,
+                             value=value, date=date,
                              number=number, unit=unit,
                              extraParams=extraParams)
 
@@ -228,7 +231,8 @@ class Resource(PrimaryEntity):
         Parameters
         ----------
         resource_category_id (int)
-            The id of :class:`~labstep.resourceCategory.ResourceCategory` to set for
+            The id of :class:`~labstep.resourceCategory.ResourceCategory`
+            to set for
             the Resource.
 
         Returns

--- a/labstep/resourceCategory.py
+++ b/labstep/resourceCategory.py
@@ -74,8 +74,7 @@ def newResourceCategory(user, name, extraParams={}):
     ResourceCategory
         An object representing the new Labstep ResourceCategory.
     """
-    filterParams = {'name': name}
-    params = {**filterParams, **extraParams}
+    params = {'name': name, **extraParams}
     return newEntity(user, ResourceCategory, params)
 
 
@@ -98,9 +97,9 @@ def editResourceCategory(resourceCategory, name=None, deleted_at=None,
     ResourceCategory
         An object representing the edited ResourceCategory.
     """
-    filterParams = {'name': name,
-                    'deleted_at': deleted_at}
-    params = {**filterParams, **extraParams}
+    params = {'name': name,
+              'deleted_at': deleted_at,
+              **extraParams}
     return editEntity(resourceCategory, params)
 
 

--- a/labstep/resourceItem.py
+++ b/labstep/resourceItem.py
@@ -28,7 +28,7 @@ def getResourceItem(user, resourceItem_id):
     return getEntity(user, ResourceItem, id=resourceItem_id)
 
 
-def getResourceItems(user, resource, count=100, search_query=None,
+def getResourceItems(user, resource_id, count=100, search_query=None,
                      extraParams={}):
     """
     Retrieve a list of a user's ResourceItems on Labstep,
@@ -39,8 +39,8 @@ def getResourceItems(user, resource, count=100, search_query=None,
     user (obj)
         The Labstep user. Must have property
         'api_key'. See 'login'.
-    resource (obj)
-        The Resource to retrieve the ResourceItems for.
+    resource_id (obj)
+        The id of Resource to retrieve the ResourceItems for.
     count (int)
         The number of ResourceItems to retrieve.
     search_query (str)
@@ -53,15 +53,15 @@ def getResourceItems(user, resource, count=100, search_query=None,
     ResourceItems
         A list of ResourceItem objects.
     """
-    filterParams = {'search_query': search_query,
-                    'resource_id': resource.id}
-    params = {**filterParams, **extraParams}
+    params = {'search_query': search_query,
+              'resource_id': resource_id,
+              **extraParams}
     return getEntities(user, ResourceItem, count, params)
 
 
-def newResourceItem(user, resource, name=None, availability=None,
+def newResourceItem(user, resource_id, name=None, availability=None,
                     quantity_amount=None, quantity_unit=None,
-                    location=None, extraParams={}):
+                    resource_location_id=None, extraParams={}):
     """
     Create a new Labstep ResourceItem.
 
@@ -70,8 +70,8 @@ def newResourceItem(user, resource, name=None, availability=None,
     user (obj)
         The Labstep user creating the ResourceItem.
         Must have property 'api_key'. See 'login'.
-    resource (obj)
-        The Resource to add a new ResourceItem to.
+    resource_id (int)
+        The id of the Resource to add a new ResourceItem to.
     name (str)
         The new name of the ResourceItem.
     availability (str)
@@ -81,30 +81,28 @@ def newResourceItem(user, resource, name=None, availability=None,
         The quantity of the ResourceItem.
     quantity_unit (str)
         The unit of the quantity.
-    location (obj)
-        The ResourceLocation of the ResourceItem.
+    resource_location_id (int)
+        The id of the ResourceLocation of the ResourceItem.
 
     Returns
     -------
     resource
         An object representing the new Labstep ResourceItem.
     """
-    filterParams = {'resource_id': resource.id,
-                    'name': name,
-                    'status': handleString(availability),
-                    'quantity_amount': quantity_amount,
-                    'quantity_unit': quantity_unit}
+    params = {'resource_id': resource_id,
+              'resource_location_id': resource_location_id,
+              'name': name,
+              'status': handleString(availability),
+              'quantity_amount': quantity_amount,
+              'quantity_unit': quantity_unit,
+              **extraParams}
 
-    if location is not None:
-        filterParams['resource_location_id'] = location.id
-
-    params = {**filterParams, **extraParams}
     return newEntity(user, ResourceItem, params)
 
 
 def editResourceItem(resourceItem, name=None, availability=None,
                      quantity_amount=None, quantity_unit=None,
-                     location_id=None, deleted_at=None, extraParams={}):
+                     resource_location_id=None, deleted_at=None, extraParams={}):
     """
     Edit an existing ResourceItem.
 
@@ -131,18 +129,16 @@ def editResourceItem(resourceItem, name=None, availability=None,
     ResourceItem
         An object representing the edited ResourceItem.
     """
-    filterParams = {'name': name,
-                    'status': handleString(availability),
-                    'quantity_unit': quantity_unit,
-                    'deleted_at': deleted_at}
+    params = {'name': name,
+              'status': handleString(availability),
+              'resource_location_id': resource_location_id,
+              'quantity_unit': quantity_unit,
+              'deleted_at': deleted_at,
+              **extraParams}
 
     if quantity_amount is not None:
-        filterParams['quantity_amount'] = float(quantity_amount)
+        params['quantity_amount'] = float(quantity_amount)
 
-    if location_id is not None:
-        filterParams['resource_location_id'] = location_id
-
-    params = {**filterParams, **extraParams}
     return editEntity(resourceItem, params)
 
 
@@ -163,7 +159,7 @@ class ResourceItem(Entity):
 
     def edit(self, name=None, availability=None,
              quantity_amount=None, quantity_unit=None,
-             location_id=None, extraParams={}):
+             resource_location_id=None, extraParams={}):
         """
         Edit an existing ResourceItem.
 
@@ -178,7 +174,7 @@ class ResourceItem(Entity):
             The quantity of the ResourceItem.
         quantity_unit (str)
             The unit of the quantity.
-        location_id (ResourceLocation)
+        resource_location_id (int)
             The id of the :class:`~labstep.resourceLocation.ResourceLocation` of the ResourceItem.
 
         Returns
@@ -195,7 +191,7 @@ class ResourceItem(Entity):
         """
         return editResourceItem(self, name=name, availability=availability,
                                 quantity_amount=quantity_amount, quantity_unit=quantity_unit,
-                                location_id=location_id, extraParams=extraParams)
+                                resource_location_id=resource_location_id, extraParams=extraParams)
 
     def delete(self):
         """
@@ -294,8 +290,8 @@ class ResourceItem(Entity):
             metadata = my_resource_item.addMetadata("Refractive Index",
                                                     value="1.73")
         """
-        return addMetadataTo(self, fieldName, fieldType, value, date,
-                             number, unit, extraParams=extraParams)
+        return addMetadataTo(self, fieldName, fieldType=fieldType, value=value, date=date,
+                             number=number, unit=unit, extraParams=extraParams)
 
     def getMetadata(self):
         """

--- a/labstep/resourceLocation.py
+++ b/labstep/resourceLocation.py
@@ -8,7 +8,7 @@ from .entity import Entity, getEntity, getEntities, newEntity, editEntity, getHe
 from .helpers import url_join, handleError
 
 
-def getResourceLocation(user, resourceLocation_id):
+def getResourceLocation(user, resource_location_id):
     """
     Retrieve a specific Labstep ResourceLocation.
 
@@ -17,7 +17,7 @@ def getResourceLocation(user, resourceLocation_id):
     user (obj)
         The Labstep user. Must have property
         'api_key'. See 'login'.
-    resourceLocation_id (int)
+    resource_location_id (int)
         The id of the ResourceLocation to retrieve.
 
     Returns
@@ -25,7 +25,7 @@ def getResourceLocation(user, resourceLocation_id):
     ResourceLocation
         An object representing a Labstep ResourceLocation.
     """
-    return getEntity(user, ResourceLocation, id=resourceLocation_id)
+    return getEntity(user, ResourceLocation, id=resource_location_id)
 
 
 def getResourceLocations(user, count=100, search_query=None, tag_id=None,
@@ -51,9 +51,9 @@ def getResourceLocations(user, count=100, search_query=None, tag_id=None,
     ResourceLocations
         A list of ResourceLocation objects.
     """
-    filterParams = {'search_query': search_query,
-                    'tag_id': tag_id}
-    params = {**filterParams, **extraParams}
+    params = {'search_query': search_query,
+              'tag_id': tag_id,
+              **extraParams}
     return getEntities(user, ResourceLocation, count, params)
 
 
@@ -77,12 +77,7 @@ def newResourceLocation(user, name, outer_location_id=None, extraParams={}):
     ResourceLocation
         An object representing the new Labstep ResourceLocation.
     """
-    filterParams = {'name': name}
-    params = {**filterParams, **extraParams}
-
-    if outer_location_id is not None:
-        params['outer_location_id'] = outer_location_id
-
+    params = {'name': name, 'outer_location_id': outer_location_id, **extraParams}
     return newEntity(user, ResourceLocation, params)
 
 
@@ -104,31 +99,8 @@ def editResourceLocation(resourceLocation, name, extraParams={}):
     ResourceLocation
         An object representing the edited ResourceLocation.
     """
-    filterParams = {'name': name}
-    params = {**filterParams, **extraParams}
+    params = {'name': name, **extraParams}
     return editEntity(resourceLocation, params)
-
-
-def deleteResourceLocation(resourceLocation):
-    """
-    Delete an existing ResourceLocation.
-
-    Parameters
-    ----------
-    resourceLocation (obj)
-        The ResourceLocation to delete.
-
-    Returns
-    -------
-    resourceLocation
-        An object representing the ResourceLocation to delete.
-    """
-    headers = getHeaders(resourceLocation.__user__)
-    url = url_join(API_ROOT, "/api/generic/", ResourceLocation.__entityName__,
-                   str(resourceLocation.id))
-    r = requests.delete(url, headers=headers)
-    handleError(r)
-    return None
 
 
 class ResourceLocation(Entity):
@@ -177,18 +149,22 @@ class ResourceLocation(Entity):
         """
         Delete an existing ResourceLocation.
 
-        Example
+        Parameters
+        ----------
+        resourceLocation (obj)
+            The ResourceLocation to delete.
+
+        Returns
         -------
-        ::
-
-            # Get all ResourceLocations, since there is no function
-            # to get one ResourceLocation.
-            resource_locations = user.getResourceLocations()
-
-            # Select the tag by using python index.
-            resource_locations[1].delete()
+        resourceLocation
+            An object representing the ResourceLocation to delete.
         """
-        return deleteResourceLocation(self)
+        headers = getHeaders(self.__user__)
+        url = url_join(API_ROOT, "/api/generic/", ResourceLocation.__entityName__,
+                       str(self.id))
+        r = requests.delete(url, headers=headers)
+        handleError(r)
+        return None
 
     '''def addComment(self, body, filepath=None):
         """

--- a/labstep/tag.py
+++ b/labstep/tag.py
@@ -33,9 +33,9 @@ def getTags(user, count=1000, type=None, search_query=None, extraParams={}):
     tags
         A list of tag objects.
     """
-    filterParams = {'search_query': search_query,
-                    'type': handleString(type)}
-    params = {**filterParams, **extraParams}
+    params = {'search_query': search_query,
+              'type': handleString(type),
+              **extraParams}
     return getEntities(user, Tag, count, params)
 
 
@@ -80,9 +80,9 @@ def newTag(user, name, type, extraParams={}):
     tag
         An object representing the new Labstep Tag.
     """
-    filterParams = {'name': name,
-                    'type': handleString(type)}
-    params = {**filterParams, **extraParams}
+    params = {'name': name,
+              'type': handleString(type),
+              **extraParams}
     return newEntity(user, Tag, params)
 
 
@@ -163,30 +163,8 @@ def editTag(tag, name, extraParams={}):
     tag
         An object representing the edited Tag.
     """
-    filterParams = {'name': name}
-    params = {**filterParams, **extraParams}
+    params = {'name': name, **extraParams}
     return editEntity(tag, params)
-
-
-def deleteTag(tag):
-    """
-    Delete an existing tag.
-
-    Parameters
-    ----------
-    tag (obj)
-        The tag to delete.
-
-    Returns
-    -------
-    tag
-        An object representing the tag to delete.
-    """
-    headers = getHeaders(tag.__user__)
-    url = url_join(API_ROOT, "/api/generic/tag/", str(tag.id))
-    r = requests.delete(url, headers=headers)
-    handleError(r)
-    return None
 
 
 class Tag(Entity):
@@ -233,17 +211,22 @@ class Tag(Entity):
 
     def delete(self):
         """
-        Delete an existing Tag.
+        Delete an existing tag.
 
-        Example
+        Parameters
+        ----------
+        tag (obj)
+            The tag to delete.
+
+        Returns
         -------
-        ::
-
-            # Get all tags, since there is no function
-            # to get one tag.
-            tags = user.getTags()
-
-            # Select the tag by using python index.
-            tags[1].delete()
+        tag
+            An object representing the tag to delete.
         """
-        return deleteTag(self)
+        headers = getHeaders(self.__user__)
+        url = url_join(API_ROOT, "/api/generic/",
+                       Tag.__entityName__,
+                       str(self.id))
+        r = requests.delete(url, headers=headers)
+        handleError(r)
+        return None

--- a/labstep/user.py
+++ b/labstep/user.py
@@ -24,19 +24,19 @@ from .resourceLocation import (getResourceLocation, getResourceLocations,
 def newUser(first_name, last_name, email, password,
             share_link_token=None, extraParams={}):
     url = url_join(API_ROOT, "public-api/user")
-    filterParams = {
+    params = {
         "first_name": first_name,
         "last_name": last_name,
         "email": email,
         "password": password,
-        "share_link_token": share_link_token
+        "share_link_token": share_link_token,
+        **extraParams
     }
-    params = {**filterParams, **extraParams}
 
-    fields = dict(
+    params = dict(
         filter(lambda field: field[1] is not None, params.items()))
 
-    r = requests.post(url, json=fields)
+    r = requests.post(url, json=params)
     handleError(r)
     return User(json.loads(r.content))
 
@@ -99,10 +99,10 @@ def login(username, password):
 
         user = labstep.login('myaccount@labstep.com', 'mypassword')
     """
-    fields = {'username': username,
+    params = {'username': username,
               'password': password}
     url = url_join(API_ROOT, "/public-api/user/login")
-    r = requests.post(url, json=fields, headers={})
+    r = requests.post(url, json=params, headers={})
     handleError(r)
     return User(json.loads(r.content))
 
@@ -219,13 +219,13 @@ class User(Entity):
         """
         return getResource(self, resource_id)
 
-    def getResourceCategory(self, resourceCategory_id):
+    def getResourceCategory(self, resource_category_id):
         """
         Retrieve a specific Labstep ResourceCategory.
 
         Parameters
         ----------
-        resourceCategory_id (int)
+        resource_category_id (int)
             The id of the ResourceCategory to retrieve.
 
         Returns
@@ -239,15 +239,15 @@ class User(Entity):
 
             entity = user.getResourceCategory(17000)
         """
-        return getResourceCategory(self, resourceCategory_id)
+        return getResourceCategory(self, resource_category_id)
 
-    def getResourceLocation(self, resourceLocation_id):
+    def getResourceLocation(self, resource_location_id):
         """
         Retrieve a specific Labstep ResourceLocation.
 
         Parameters
         ----------
-        resourceLocation_id (int)
+        resource_location_id (int)
             The id of the ResourceLocation to retrieve.
 
         Returns
@@ -261,7 +261,7 @@ class User(Entity):
 
             entity = user.getResourceLocation(17000)
         """
-        return getResourceLocation(self, resourceLocation_id)
+        return getResourceLocation(self, resource_location_id)
 
     def getOrderRequest(self, order_request_id):
         """
@@ -763,7 +763,7 @@ class User(Entity):
             Give your ResourceLocation a name.
 
         outer_location_id (int)
-            Id of existing location to create the location within
+            The id of existing location to create the location within
 
         extraParams (dict)
             (Advanced) Dictionary of extra parameters to pass in the
@@ -785,14 +785,15 @@ class User(Entity):
                                    outer_location_id=outer_location_id,
                                    extraParams=extraParams)
 
-    def newOrderRequest(self, resource, quantity=1, extraParams={}):
+    def newOrderRequest(self, resource_id, quantity=1, extraParams={}):
         """
         Create a new Labstep OrderRequest.
 
         Parameters
         ----------
-        resource (Resource)
-            The :class:`~labstep.resource.Resource` to request more items of.
+        resource_id (int)
+            The id of the :class:`~labstep.resource.Resource`
+            to request more items of.
         quantity (int)
             The quantity of items requested.
 
@@ -806,9 +807,11 @@ class User(Entity):
         ::
 
             my_resource = user.getResource(17000)
-            entity = user.newOrderRequest(my_resource, quantity=2)
+            entity = user.newOrderRequest(my_resource.id, quantity=2)
         """
-        return newOrderRequest(self, resource, quantity=quantity,
+        return newOrderRequest(self,
+                               resource_id=resource_id,
+                               quantity=quantity,
                                extraParams=extraParams)
 
     def newTag(self, name, type, extraParams={}):

--- a/labstep/workspace.py
+++ b/labstep/workspace.py
@@ -59,8 +59,7 @@ def getWorkspaces(user, count=100, search_query=None, extraParams={}):
     workspaces
         A list of Workspace objects.
     """
-    filterParams = {'name': search_query}
-    params = {**filterParams, **extraParams}
+    params = {'name': search_query, **extraParams}
     return getEntities(user, Workspace, count, params)
 
 
@@ -81,8 +80,7 @@ def newWorkspace(user, name, extraParams={}):
     workspace
         An object representing the new Labstep Workspace.
     """
-    filterParams = {'name': name}
-    params = {**filterParams, **extraParams}
+    params = {'name': name, **extraParams}
     return newEntity(user, Workspace, params)
 
 
@@ -104,9 +102,9 @@ def editWorkspace(workspace, name=None, deleted_at=None, extraParams={}):
     workspace
         An object representing the Workspace to edit.
     """
-    filterParams = {'name': name,
-                    'deleted_at': deleted_at}
-    params = {**filterParams, **extraParams}
+    params = {'name': name,
+              'deleted_at': deleted_at,
+              **extraParams}
     return editEntity(workspace, params)
 
 
@@ -200,8 +198,7 @@ class Workspace(Entity):
                                               created_at_to='2019-01-31',
                                               tag_id=800)
         """
-        groupParams = {'group_id': self.id}
-        extraParams = {**groupParams, **extraParams}
+        extraParams = {'group_id': self.id, **extraParams}
         return getExperiments(self.__user__, count, search_query,
                               created_at_from, created_at_to, tag_id,
                               extraParams=extraParams)
@@ -242,8 +239,7 @@ class Workspace(Entity):
                                             created_at_to='2019-01-31',
                                             tag_id=800)
         """
-        groupParams = {'group_id': self.id}
-        extraParams = {**groupParams, **extraParams}
+        extraParams = {'group_id': self.id, **extraParams}
         return getProtocols(self.__user__, count, search_query,
                             created_at_from, created_at_to, tag_id,
                             extraParams=extraParams)
@@ -275,8 +271,7 @@ class Workspace(Entity):
             entity = workspace.getResources(search_query='bacteria',
                                             tag_id=800)
         """
-        groupParams = {'group_id': self.id}
-        extraParams = {**groupParams, **extraParams}
+        extraParams = {'group_id': self.id, **extraParams}
         return getResources(self.__user__, count, search_query,
                             tag_id, extraParams=extraParams)
 
@@ -307,8 +302,7 @@ class Workspace(Entity):
             entity = workspace.getResourceCategorys(search_query='properties',
                                                     tag_id=800)
         """
-        groupParams = {'group_id': self.id}
-        extraParams = {**groupParams, **extraParams}
+        extraParams = {'group_id': self.id, **extraParams}
         return getResourceCategorys(self.__user__, count, search_query, tag_id,
                                     extraParams=extraParams)
 
@@ -336,8 +330,7 @@ class Workspace(Entity):
             entity = workspace.getResourceLocations(search_query='properties',
                                                     tag_id=800)
         """
-        groupParams = {'group_id': self.id}
-        extraParams = {**groupParams, **extraParams}
+        extraParams = {'group_id': self.id, **extraParams}
         return getResourceLocations(self.__user__, count, search_query,
                                     extraParams=extraParams)
 
@@ -396,8 +389,7 @@ class Workspace(Entity):
 
             entity = workspace.getTags(search_query='bacteria')
         """
-        groupParams = {'group_id': self.id}
-        extraParams = {**groupParams, **extraParams}
+        extraParams = {'group_id': self.id, **extraParams}
         return getTags(self.__user__, count, type, search_query,
                        extraParams=extraParams)
 
@@ -428,8 +420,7 @@ class Workspace(Entity):
 
             files = workspace.getFiles(search_query='bacteria')
         """
-        groupParams = {'group_id': self.id}
-        extraParams = {**groupParams, **extraParams}
+        extraParams = {'group_id': self.id, **extraParams}
         return getFiles(self.__user__, count, search_query, file_type, extraParams=extraParams)
 
     def sendInvites(self, emails, message):

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -110,8 +110,8 @@ class TestExperiment:
         entity.addMaterial('testMaterial',
                            amount=10,
                            units='uL',
-                           resource=resource,
-                           resource_item=resource_item)
+                           resource_id=resource.id,
+                           resource_item_id=resource_item.id)
         material = entity.getMaterials()[0]
         assert material.name == 'testMaterial' \
             and material.amount == '10' \

--- a/tests/test_experiment_protocol.py
+++ b/tests/test_experiment_protocol.py
@@ -42,8 +42,8 @@ class TestExperimentProtocol:
         experiment_protocol.addMaterial('testMaterial',
                                         amount=10,
                                         units='uL',
-                                        resource=resource,
-                                        resource_item=resource_item)
+                                        resource_id=resource.id,
+                                        resource_item_id=resource_item.id)
 
         updated_exp = testUser.getExperiment(new_entity.id)
         updated_exp_protocol = updated_exp.getProtocols()[0]

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -127,7 +127,7 @@ class TestProtocol:
         assert len(dataElements) == 0
 
     def test_addDataElement(self):
-        metadata = entity.addDataElement(fieldType="default", fieldName="test")
+        entity.addDataElement(fieldType="default", fieldName="test")
         newEntity = testUser.getProtocol(entity.id)
         dataElements = newEntity.getDataElements()
         assert len(dataElements) == 1

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -59,7 +59,7 @@ class TestResource:
 
     def test_setResourceCategory(self):
         my_resourceCategory = testUser.getResourceCategorys()[0]
-        result = entity.setResourceCategory(my_resourceCategory)
+        result = entity.setResourceCategory(my_resourceCategory.id)
         assert result.resource_category is not None, \
             'FAILED TO ADD METADATA'
 

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -66,7 +66,7 @@ class TestSharing:
             'FAILED TO SHARE RESOURCE CATEGORY'
 
     def test_share_orderRequest(self):
-        entity = testUser.newOrderRequest(testUser.newResource(testName))
+        entity = testUser.newResource(testName).newOrderRequest()
         entity.shareWith(workspace.id, 'view')
         permission = entity.getPermissions()[0]
         permission.set('edit')

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -63,7 +63,7 @@ class TestUser:
 
     def test_getOrderRequest(self):
         new_resource = testUser.newResource(testName)
-        entity = testUser.newOrderRequest(new_resource)
+        entity = testUser.newOrderRequest(resource_id=new_resource.id)
         result = testUser.getOrderRequest(entity.id)
         assert result.name == testName, \
             'FAILED TO GET ORDER REQUEST'
@@ -160,7 +160,7 @@ class TestUser:
 
     def test_newOrderRequest(self):
         entity = testUser.newResource(testName)
-        result = testUser.newOrderRequest(entity)
+        result = testUser.newOrderRequest(resource_id=entity.id)
         assert result.name == testName, \
             'FAILED TO CREATE NEW ORDER REQUEST'
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -60,7 +60,7 @@ class TestWorkspace:
 
     def test_getOrderRequests(self):
         new_resource = testUser.newResource(testName)
-        testUser.newOrderRequest(new_resource)
+        new_resource.newOrderRequest()
         result = entity.getOrderRequests()
         assert result[0].id, \
             'FAILED TO GET ORDER REQUESTS'


### PR DESCRIPTION
- Methods that previously took an Entity object as a parameter now only require the id of the entity.