### PR TITLE
Updates for single page editor

### DIFF
--- a/examples/workspace_setup.py
+++ b/examples/workspace_setup.py
@@ -13,8 +13,7 @@ user.setWorkspace(workspace.id)
 
 
 # Create an Experiment
-my_experiment = user.newExperiment(name='Trial 1',
-                                        description='Aspirin is a drug...')
+my_experiment = user.newExperiment(name='Trial 1')
 
 # Upload the reaction scheme
 user.newFile('./aspirin_reaction_scheme.png')

--- a/labstep/entity.py
+++ b/labstep/entity.py
@@ -133,6 +133,33 @@ def newEntity(user, entityClass, fields):
     return entityClass(json.loads(r.content), user)
 
 
+def newEntities(user, entityClass, items):
+    """
+    Parameters
+    ----------
+    user (obj)
+        The Labstep user.
+    entityClass (class)
+        The Class of the entity to retrieve.
+    items (List[])
+        List of info on entities to create.
+
+    Returns
+    -------
+    entities
+        List of Labstep Entities created.
+    """
+    headers = getHeaders(user)
+    url = url_join(API_ROOT,
+                   "/api/generic/",
+                   entityClass.__entityName__,
+                   'batch')
+    r = requests.post(url, headers=headers, json={"items": items})
+    handleError(r)
+    entities = json.loads(r.content)
+    return list(map(lambda entity: entityClass(entity, user), entities))
+
+
 def editEntity(entity, fields):
     """
     Parameters

--- a/labstep/entity.py
+++ b/labstep/entity.py
@@ -201,6 +201,6 @@ class Entity:
         return pp.pformat(entity_attributes)
 
     def update(self):
-        return update(self, getEntity(self.__user__,
-                                      type(self),
-                                      self.id).__data__)
+        data = getEntity(self.__user__, type(self), self.id).__data__
+        self.__init__(data, self.__user__)
+        return self

--- a/labstep/entity.py
+++ b/labstep/entity.py
@@ -184,7 +184,7 @@ def editEntity(entity, fields):
                    entity.__entityName__, str(entity.id))
     r = requests.put(url, json=new_fields, headers=headers)
     handleError(r)
-    return entity.update()
+    return update(entity, json.loads(r.content))
 
 
 class Entity:

--- a/labstep/entity.py
+++ b/labstep/entity.py
@@ -184,7 +184,7 @@ def editEntity(entity, fields):
                    entity.__entityName__, str(entity.id))
     r = requests.put(url, json=new_fields, headers=headers)
     handleError(r)
-    return update(entity, json.loads(r.content))
+    return entity.update()
 
 
 class Entity:

--- a/labstep/experiment.py
+++ b/labstep/experiment.py
@@ -910,7 +910,7 @@ class Experiment(PrimaryEntity):
                                  resource_id=resource.id)
         """
 
-        params = {'experiment_id': self.root_experiment['id'],
+        params = {'experiment_id': self.entry.id,
                   'name': name,
                   'resource_id': resource_id,
                   'resource_item_id': resource_item_id,

--- a/labstep/experiment.py
+++ b/labstep/experiment.py
@@ -666,8 +666,8 @@ class Experiment(PrimaryEntity):
 
     def __init__(self, data, user):
         super().__init__(data, user)
-        self.entry = ExperimentProtocol(self.root_experiment, user)
-        del self.root_experiment
+        self.entry = self.state
+        self.root_experiment = ExperimentProtocol(self.root_experiment, user)
 
     def edit(self, name=None, entry=None, started_at=None, extraParams={}):
         """
@@ -796,7 +796,7 @@ class Experiment(PrimaryEntity):
             dataElement = experiment.addDataElement("Refractive Index",
                                                value="1.73")
         """
-        return self.entry.addDataElement(fieldName=fieldName,
+        return self.root_experiment.addDataElement(fieldName=fieldName,
                                          fieldType=fieldType,
                                          value=value,
                                          date=date,
@@ -821,7 +821,7 @@ class Experiment(PrimaryEntity):
             exp_protocol = experiment.getProtocols()[0]
             dataElements = exp_protocol.getDataElements()
         """
-        return self.entry.getDataElements()
+        return self.root_experiment.getDataElements()
 
     def getSignatures(self):
         """
@@ -875,7 +875,7 @@ class Experiment(PrimaryEntity):
             exp_materials = experiment.getMaterials()
             print(exp_materials[0])
         """
-        return self.entry.getMaterials()
+        return self.root_experiment.getMaterials()
 
     def addMaterial(self, name=None, amount=None, units=None, resource_id=None, resource_item_id=None,
                     extraParams={}):
@@ -910,7 +910,7 @@ class Experiment(PrimaryEntity):
                                  resource_id=resource.id)
         """
 
-        params = {'experiment_id': self.entry.id,
+        params = {'experiment_id': self.root_experiment.id,
                   'name': name,
                   'resource_id': resource_id,
                   'resource_item_id': resource_item_id,

--- a/labstep/experiment.py
+++ b/labstep/experiment.py
@@ -685,8 +685,11 @@ class Experiment(PrimaryEntity):
 
     def __init__(self, data, user):
         super().__init__(data, user)
-        self.entry = self.state
-        self.root_experiment = ExperimentProtocol(self.root_experiment, user)
+        if hasattr(self, 'state'):
+            self.entry = self.state
+        if hasattr(self, 'root_experiment'):
+            self.root_experiment = ExperimentProtocol(
+                self.root_experiment, user)
 
     def edit(self, name=None, entry=None, started_at=None, extraParams={}):
         """

--- a/labstep/experiment.py
+++ b/labstep/experiment.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # pylama:ignore=E501
 
-from .entity import Entity, getEntity, getEntities, newEntity, editEntity
+from .entity import Entity, getEntity, getEntities, newEntity, newEntities, editEntity
 from .primaryEntity import PrimaryEntity
 from .comment import getComments, addCommentWithFile
 from .helpers import (getTime, createdAtFrom, createdAtTo,
@@ -257,6 +257,25 @@ class ExperimentProtocol(Entity):
             params['value'] = str(params['value'])
 
         return newEntity(self.__user__, ExperimentMaterial, params)
+
+    def addSteps(self, N):
+        """
+        Add steps to a Protocol within an Experiment
+
+        Parameters
+        ----------
+        N (int)
+            The number of steps to add.
+
+        Example
+        -------
+        ::
+            experiment = user.getExperiment(17000)
+            exp_protocol = experiment.getProtocols()[0]
+            exp_protocol_steps = exp_protocol.addSteps(5)
+        """
+        steps = [{"experiment_id": self.id}]*N
+        return newEntities(self.__user__, ExperimentStep, steps)
 
     def getSteps(self):
         """
@@ -797,12 +816,12 @@ class Experiment(PrimaryEntity):
                                                value="1.73")
         """
         return self.root_experiment.addDataElement(fieldName=fieldName,
-                                         fieldType=fieldType,
-                                         value=value,
-                                         date=date,
-                                         number=number,
-                                         unit=unit,
-                                         extraParams=extraParams)
+                                                   fieldType=fieldType,
+                                                   value=value,
+                                                   date=date,
+                                                   number=number,
+                                                   unit=unit,
+                                                   extraParams=extraParams)
 
     def getDataElements(self):
         """

--- a/labstep/experiment.py
+++ b/labstep/experiment.py
@@ -70,7 +70,7 @@ def getExperiments(user, count=100, search_query=None,
     return getEntities(user, Experiment, count, params)
 
 
-def newExperiment(user, name, description=None, extraParams={}):
+def newExperiment(user, name, entry=None, extraParams={}):
     """
     Create a new Labstep Experiment.
 
@@ -80,9 +80,9 @@ def newExperiment(user, name, description=None, extraParams={}):
         The Labstep user creating the Experiment.
         Must have property 'api_key'. See 'login'.
     name (str)
-        Give your Experiment a name.
-    description (str)
-        Give your Experiment a description.
+        The name of the experiment.
+    entry (obj)
+        A JSON object representing the state of the Experiment Entry.
 
     Returns
     -------
@@ -90,12 +90,12 @@ def newExperiment(user, name, description=None, extraParams={}):
         An object representing the new Labstep Experiment.
     """
     params = {'name': name,
-              'description': description,
+              'state': entry,
               **extraParams}
     return newEntity(user, Experiment, params)
 
 
-def editExperiment(experiment, name=None, description=None, started_at=None,
+def editExperiment(experiment, name=None, entry=None, started_at=None,
                    deleted_at=None, extraParams={}):
     """
     Edit an existing Experiment.
@@ -106,8 +106,8 @@ def editExperiment(experiment, name=None, description=None, started_at=None,
         The Experiment to edit.
     name (str)
         The new name of the Experiment.
-    description (str)
-        The new description for the Experiment.
+    entry (obj)
+        A JSON object representing the state of the Experiment Entry.
     started_at (str)
         The start date of the Experiment in the format of "YYYY-MM-DD HH:MM".
     deleted_at (str)
@@ -119,7 +119,7 @@ def editExperiment(experiment, name=None, description=None, started_at=None,
         An object representing the edited Experiment.
     """
     params = {'name': name,
-              'state': description,
+              'state': entry,
               'started_at': handleDate(started_at),
               'deleted_at': deleted_at,
               **extraParams}
@@ -668,7 +668,7 @@ class Experiment(PrimaryEntity):
         super().__init__(data, user)
         self.entry = ExperimentProtocol(self.root_experiment, user)
 
-    def edit(self, name=None, description=None, started_at=None, extraParams={}):
+    def edit(self, name=None, entry=None, started_at=None, extraParams={}):
         """
         Edit an existing Experiment.
 
@@ -676,8 +676,8 @@ class Experiment(PrimaryEntity):
         ----------
         name (str)
             The new name of the Experiment.
-        description (str)
-            The new description of the Experiment.
+        entry (obj)
+            A JSON object representing the state of the Experiment Entry.
         started_at (str)
             The start date of the Experiment in the format of "YYYY-MM-DD HH:MM".
 
@@ -692,10 +692,9 @@ class Experiment(PrimaryEntity):
 
             my_experiment = user.getExperiment(17000)
             my_experiment.edit(name='A New Experiment Name',
-                               description='A new description!',
                                started_at='2018-06-06 12:05')
         """
-        return editExperiment(self, name, description, started_at, extraParams=extraParams)
+        return editExperiment(self, name=name, entry=entry, started_at=started_at, extraParams=extraParams)
 
     def delete(self):
         """

--- a/labstep/experiment.py
+++ b/labstep/experiment.py
@@ -664,6 +664,10 @@ class Experiment(PrimaryEntity):
     """
     __entityName__ = 'experiment-workflow'
 
+    def __init__(self, data, user):
+        super().__init__(data, user)
+        self.entry = ExperimentProtocol(self.root_experiment, user)
+
     def edit(self, name=None, description=None, started_at=None, extraParams={}):
         """
         Edit an existing Experiment.
@@ -792,9 +796,13 @@ class Experiment(PrimaryEntity):
             dataElement = experiment.addDataElement("Refractive Index",
                                                value="1.73")
         """
-        return addMetadataTo(self, fieldName, fieldType, value, date,
-                             number, unit,
-                             extraParams=extraParams)
+        return self.entry.addDataElement(fieldName=fieldName,
+                                         fieldType=fieldType,
+                                         value=value,
+                                         date=date,
+                                         number=number,
+                                         unit=unit,
+                                         extraParams=extraParams)
 
     def getDataElements(self):
         """
@@ -813,7 +821,7 @@ class Experiment(PrimaryEntity):
             exp_protocol = experiment.getProtocols()[0]
             dataElements = exp_protocol.getDataElements()
         """
-        return getMetadata(self)
+        return self.entry.getDataElements()
 
     def getSignatures(self):
         """
@@ -850,7 +858,7 @@ class Experiment(PrimaryEntity):
         }
         return newEntity(self.__user__, ExperimentSignature, params)
 
-    def getMaterials(self, count=100):
+    def getMaterials(self):
         """
         Returns a list of the materials in the Experiment.
 
@@ -867,9 +875,7 @@ class Experiment(PrimaryEntity):
             exp_materials = experiment.getMaterials()
             print(exp_materials[0])
         """
-        return getEntities(self.__user__, ExperimentMaterial,
-                           count=count,
-                           filterParams={'experiment_workflow_id': self.id})
+        return self.entry.getMaterials()
 
     def addMaterial(self, name=None, amount=None, units=None, resource_id=None, resource_item_id=None,
                     extraParams={}):

--- a/labstep/experiment.py
+++ b/labstep/experiment.py
@@ -667,6 +667,7 @@ class Experiment(PrimaryEntity):
     def __init__(self, data, user):
         super().__init__(data, user)
         self.entry = ExperimentProtocol(self.root_experiment, user)
+        del self.root_experiment
 
     def edit(self, name=None, entry=None, started_at=None, extraParams={}):
         """

--- a/labstep/protocol.py
+++ b/labstep/protocol.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from .primaryEntity import PrimaryEntity
-from .entity import Entity, getEntity, getEntities, newEntity, editEntity
+from .metadata import Metadata
 from .helpers import (listToClass, getTime, handleDate,
                       createdAtFrom, createdAtTo)
-from .metadata import Metadata
+from .primaryEntity import PrimaryEntity
+from .entity import (Entity, getEntity, getEntities,
+                     newEntity, newEntities, editEntity)
 
 
 def getProtocol(user, protocol_id):
@@ -118,6 +119,7 @@ def editProtocol(protocol, name=None, content_state=None, deleted_at=None,
         editEntity(ProtocolVersion(protocol.last_version,
                                    protocol.__user__),
                    {"content_state": content_state})
+        protocol.update()
 
     return editEntity(protocol, params)
 
@@ -337,6 +339,24 @@ class Protocol(PrimaryEntity):
         """
         newEntity(self.__user__, ProtocolVersion, {"collection_id": self.id})
         return self.update()
+
+    def addSteps(self, N):
+        """
+        Add steps to the protocol
+
+        Parameters
+        ----------
+        N (int)
+            The number of steps to add.
+
+        Example
+        -------
+        ::
+            my_protocol = user.newProtocol('My API Protocol')
+            my_protocol.addSteps(5)
+        """
+        steps = [{"protocol_id": self.last_version["id"]}]*N
+        return newEntities(self.__user__, ProtocolStep, steps)
 
     def getSteps(self):
         """

--- a/labstep/user.py
+++ b/labstep/user.py
@@ -657,7 +657,7 @@ class User(Entity):
 
     # newEntity()
 
-    def newExperiment(self, name, description=None, extraParams={}):
+    def newExperiment(self, name, entry=None, extraParams={}):
         """
         Create a new Labstep Experiment.
 
@@ -665,8 +665,8 @@ class User(Entity):
         ----------
         name (str)
             Give your Experiment a name.
-        description (str)
-            Give your Experiment a description.
+        entry (obj)
+            A JSON object representing the state of the Experiment Entry.
 
         Returns
         -------
@@ -677,12 +677,10 @@ class User(Entity):
         -------
         ::
 
-            entity = user.newExperiment(name='The Synthesis of Aspirin',
-                                        description='Aspirin is an analgesic
-                                        used to reduce pain.')
+            entity = user.newExperiment(name='The Synthesis of Aspirin')
         """
         return newExperiment(self, name,
-                             description=description,
+                             entry=entry,
                              extraParams=extraParams)
 
     def newProtocol(self, name, extraParams={}):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -20,6 +20,26 @@ tableData = {
     }
 }
 
+proseMirrorState = {
+    "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "attrs": {"align": None},
+                    "content": [
+                        {
+                            "type": "text",
+                                    "text": "test"
+                        }
+                    ]
+                },
+                {
+                    "type": "paragraph",
+                    "attrs": {"align": None}
+                }
+            ]
+}
+
 
 contentStateEmpty = {
     "object": "value",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -141,9 +141,20 @@ def contentStateWithSteps(steps):
     }
 
 
-def protocol():
-    new_entity = user.newProtocol(testString)
-    entity = user.getProtocol(new_entity.id)
+def experiment(empty=False):
+    entity = user.newExperiment(testString)
+    if empty is True:
+        return entity
+    entity.addProtocol(user.newProtocol(testString))
+    entity.addMaterial(testString)
+    return entity.update()
+
+
+def protocol(empty=False):
+    entity = user.newProtocol(testString)
+    if empty is True:
+        return entity
+
     entity.addComment(testString)
     entity.addMaterial(testString, amount='0.1', units='ml')
     entity.addTimer(name=testString, hours=4, minutes=15)
@@ -151,12 +162,12 @@ def protocol():
     steps = entity.addSteps(2)
     entity.edit(content_state=contentStateWithSteps(steps))
 
-    return user.getProtocol(entity.id)
+    return entity.update()
 
 
 def experimentProtocol():
     entity = user.newExperiment(testString)
-    experiment_protocol = entity.addProtocol(protocol(user))
+    experiment_protocol = entity.addProtocol(protocol())
     return experiment_protocol
 
 
@@ -164,13 +175,14 @@ def resource():
     entity = user.newResource(testString)
     entity.addMetadata(fieldName='test', value=testString)
     entity.addComment(testString)
-    return entity
+    return entity.update()
 
 
 def resourceCategory():
-    entity = user.newResourceCategory(testString())
+    entity = user.newResourceCategory(testString)
     entity.addMetadata(fieldName='test', value=testString)
     entity.addComment(testString)
+    return entity.update()
 
 
 def orderRequest():
@@ -178,14 +190,14 @@ def orderRequest():
     entity = new_resource.newOrderRequest()
     entity.addMetadata(fieldName='test', value=testString)
     entity.addComment(testString)
-    return entity
+    return entity.update()
 
 
 def resourceItem():
     entity = resource().newItem(name='Pytest Acetone')
     entity.addMetadata(fieldName='test', value=testString)
     entity.addComment(testString)
-    return entity
+    return entity.update()
 
 
 def resourceLocation():

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,31 +1,32 @@
 import labstep
 
+user = labstep.login('apitest@labstep.com', 'apitestpass')
 
 tableData = {
-        "rowCount": 6,
-        "columnCount": 6,
-        "colHeaderData": {},
-        "data": {
-            "dataTable": {
+    "rowCount": 6,
+    "columnCount": 6,
+    "colHeaderData": {},
+    "data": {
+        "dataTable": {
+            0: {
                 0: {
-                    0: {
-                        "value": 'Cell A1'
-                    },
-                    1: {
-                        "value": 'Cell B1'
-                    }
+                    "value": 'Cell A1'
+                },
+                1: {
+                    "value": 'Cell B1'
                 }
             }
         }
     }
+}
 
 
 contentStateEmpty = {
-        "object": "value",
-        "document": {
-            "object": "document",
-            "data": [],
-            "nodes": [
+    "object": "value",
+    "document": {
+        "object": "document",
+        "data": [],
+        "nodes": [
                 {
                     "object": "block",
                     "type": "paragraph",
@@ -44,9 +45,16 @@ contentStateEmpty = {
                         }
                     ]
                 },
-            ]
-        }
+        ]
     }
+}
+
+
+testString = labstep.helpers.getTime()
+
+
+def newString():
+    return labstep.helpers.getTime()
 
 
 def contentStateWithSteps(steps):
@@ -133,24 +141,56 @@ def contentStateWithSteps(steps):
     }
 
 
-def protocolWithElements(user):
-
-    testName = labstep.helpers.getTime()
-    new_entity = user.newProtocol(testName)
+def protocol():
+    new_entity = user.newProtocol(testString)
     entity = user.getProtocol(new_entity.id)
-    entity.addComment(testName)
-    entity.addMaterial(testName, amount='0.1', units='ml')
-    entity.addTimer(name=testName, hours=4, minutes=15)
-    entity.addTable(name=testName, data=tableData)
+    entity.addComment(testString)
+    entity.addMaterial(testString, amount='0.1', units='ml')
+    entity.addTimer(name=testString, hours=4, minutes=15)
+    entity.addTable(name=testString, data=tableData)
     steps = entity.addSteps(2)
     entity.edit(content_state=contentStateWithSteps(steps))
 
     return user.getProtocol(entity.id)
 
 
-def experimentProtocol(user):
-    testName = labstep.helpers.getTime()
-    entity = user.newExperiment(testName)
-    protocol = protocolWithElements(user)
-    experiment_protocol = entity.addProtocol(protocol)
+def experimentProtocol():
+    entity = user.newExperiment(testString)
+    experiment_protocol = entity.addProtocol(protocol(user))
     return experiment_protocol
+
+
+def resource():
+    entity = user.newResource(testString)
+    entity.addMetadata(fieldName='test', value=testString)
+    entity.addComment(testString)
+    return entity
+
+
+def resourceCategory():
+    entity = user.newResourceCategory(testString())
+    entity.addMetadata(fieldName='test', value=testString)
+    entity.addComment(testString)
+
+
+def orderRequest():
+    new_resource = resource()
+    entity = new_resource.newOrderRequest()
+    entity.addMetadata(fieldName='test', value=testString)
+    entity.addComment(testString)
+    return entity
+
+
+def resourceItem():
+    entity = resource().newItem(name='Pytest Acetone')
+    entity.addMetadata(fieldName='test', value=testString)
+    entity.addComment(testString)
+    return entity
+
+
+def resourceLocation():
+    return user.newResourceLocation(testString)
+
+
+def workspace():
+    return user.newWorkspace(testString)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,156 @@
+import labstep
+
+
+tableData = {
+        "rowCount": 6,
+        "columnCount": 6,
+        "colHeaderData": {},
+        "data": {
+            "dataTable": {
+                0: {
+                    0: {
+                        "value": 'Cell A1'
+                    },
+                    1: {
+                        "value": 'Cell B1'
+                    }
+                }
+            }
+        }
+    }
+
+
+contentStateEmpty = {
+        "object": "value",
+        "document": {
+            "object": "document",
+            "data": [],
+            "nodes": [
+                {
+                    "object": "block",
+                    "type": "paragraph",
+                    "isVoid": False,
+                    "data": [],
+                    "nodes": [
+                        {
+                            "object": "text",
+                            "leaves": [
+                                {
+                                    "object": "leaf",
+                                    "text": " ",
+                                    "marks": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+            ]
+        }
+    }
+
+
+def contentStateWithSteps(steps):
+    return {
+        "object": "value",
+        "document": {
+            "object": "document",
+            "data": [],
+            "nodes": [
+                {
+                    "object": "block",
+                    "type": "paragraph",
+                    "isVoid": False,
+                    "data": [],
+                    "nodes": [
+                        {
+                            "object": "text",
+                            "leaves": [
+                                {
+                                    "object": "leaf",
+                                    "text": " ",
+                                    "marks": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "object": "block",
+                    "type": "protocol_step",
+                    "isVoid": False,
+                    "data": {"id": steps[0].id},
+                    "nodes": [
+                        {
+                            "object": "text",
+                            "leaves": [
+                                {
+                                    "object": "leaf",
+                                    "text": " ",
+                                    "marks": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "object": "block",
+                    "type": "protocol_step",
+                    "isVoid": False,
+                    "data": {"id": steps[1].id},
+                    "nodes": [
+                        {
+                            "object": "text",
+                            "leaves": [
+                                {
+                                    "object": "leaf",
+                                    "text": " ",
+                                    "marks": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "object": "block",
+                    "type": "paragraph",
+                    "isVoid": False,
+                    "data": [],
+                    "nodes": [
+                        {
+                            "object": "text",
+                            "leaves": [
+                                {
+                                    "object": "leaf",
+                                    "text": " ",
+                                    "marks": []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+
+
+def protocolWithElements(user):
+
+    testName = labstep.helpers.getTime()
+    new_entity = user.newProtocol(testName)
+    entity = user.getProtocol(new_entity.id)
+    entity.addComment(testName)
+    entity.addMaterial(testName, amount='0.1', units='ml')
+    entity.addTimer(name=testName, hours=4, minutes=15)
+    entity.addTable(name=testName, data=tableData)
+    steps = entity.addSteps(2)
+    entity.edit(content_state=contentStateWithSteps(steps))
+
+    return user.getProtocol(entity.id)
+
+
+def experimentProtocol(user):
+    testName = labstep.helpers.getTime()
+    entity = user.newExperiment(testName)
+    protocol = protocolWithElements(user)
+    experiment_protocol = entity.addProtocol(protocol)
+    return experiment_protocol

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from fixtures import experiment, protocol, user, testString
+from fixtures import experiment, protocol, resource, testString
 
-
-# Make new entity
 entity = experiment()
-protocol = protocol()
-exp_protocol = entity.addProtocol(protocol)
-entity = user.getExperiment(entity.id)
 
 
 class TestExperiment:
@@ -38,13 +33,13 @@ class TestExperiment:
             'FAILED TO EDIT EXPERIMENT'
 
     def test_delete(self):
-        entityToDelete = user.newExperiment(testString)
+        entityToDelete = experiment()
         result = entityToDelete.delete()
         assert result.deleted_at is not None, \
             'FAILED TO DELETE EXPERIMENT'
 
     def test_addProtocol(self):
-        get_protocol = user.newProtocol('Test')
+        get_protocol = protocol(empty=True)
         result = entity.addProtocol(get_protocol)
         assert result is not None, \
             'FAILED TO ADD PROTOCOL TO EXPERIMENT'
@@ -69,18 +64,6 @@ class TestExperiment:
         assert result[0].id is not None, \
             'FAILED TO GET TAGS'
 
-    # ExperimentStep
-    def test_getSteps(self):
-        result = exp_protocol.getSteps()
-        assert result[0].id is not None, \
-            'FAILED TO GET STEPS'
-
-    def test_completeStep(self):
-        steps = exp_protocol.getSteps()
-        result = steps[0].complete()
-        assert result.ended_at is not None, \
-            'FAILED TO COMPLETE STEP'
-
     def test_commenting_on_comments(self):
         comment = entity.getComments()[0]
         comment.addComment('test')
@@ -93,24 +76,24 @@ class TestExperiment:
         assert len(dataElements) == 0
 
     def test_addDataElementTo(self):
-        entity.addDataElement('testField', fieldType="default",)
-        newEntity = user.getExperiment(entity.id)
-        dataElements = newEntity.getDataElements()
+        entity.addDataElement('testField', fieldType="default")
+        entity.update()
+        dataElements = entity.getDataElements()
         assert len(dataElements) == 1
 
     def test_addMaterial(self):
-        resource = user.newResource('test')
-        resource_item = resource.newItem('test')
+        test_resource = resource()
+        resource_item = test_resource.newItem('test')
         entity.addMaterial('testMaterial',
                            amount=10,
                            units='uL',
-                           resource_id=resource.id,
+                           resource_id=test_resource.id,
                            resource_item_id=resource_item.id)
-        material = entity.getMaterials()[0]
+        material = entity.getMaterials()[1]
         assert material.name == 'testMaterial' \
             and material.amount == '10' \
             and material.units == 'uL' \
-            and material.resource['id'] == resource.id \
+            and material.resource['id'] == test_resource.id \
             and material.resource_item['id'] == resource_item.id \
 
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,35 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from fixtures import experiment, protocol, resource, testString
+from fixtures import (experiment, protocol, resource,
+                      testString, proseMirrorState)
 
 entity = experiment()
 
 
 class TestExperiment:
     def test_edit(self):
-        content_state = {
-            "type": "doc",
-            "content": [
-                {
-                    "type": "paragraph",
-                    "attrs": {"align": None},
-                    "content": [
-                        {
-                            "type": "text",
-                                    "text": "test"
-                        }
-                    ]
-                },
-                {
-                    "type": "paragraph",
-                    "attrs": {"align": None}
-                }
-            ]
-        }
 
-        result = entity.edit('Pytest Edited', content_state)
-        assert result.name == 'Pytest Edited', \
+        entity.edit('Pytest Edited', entry=proseMirrorState)
+        entity.update()
+        assert entity.name == 'Pytest Edited' and \
+            entity.entry == proseMirrorState,\
             'FAILED TO EDIT EXPERIMENT'
 
     def test_delete(self):

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -3,36 +3,16 @@
 
 import labstep
 
+from fixtures import protocolWithElements
+
 testUser = labstep.login('apitest@labstep.com', 'apitestpass')
 
 # Set variables
 testName = labstep.helpers.getTime()
 
 # Make new entity
-new_entity = testUser.newExperiment(testName)
-entity = testUser.getExperiment(new_entity.id)
-protocol = testUser.newProtocol('Test')
-protocol.addComment(testName)
-protocol.addComment(testName)
-data = {
-    "rowCount": 6,
-    "columnCount": 6,
-    "colHeaderData": {},
-    "data": {
-        "dataTable": {
-            0: {
-                0: {
-                    "value": 'Cell A1'
-                },
-                1: {
-                    "value": 'Cell B1'
-                }
-            }
-        }
-    }
-}
-protocol.addTable(name=testName, data=data)
-protocol = testUser.getProtocol(protocol.id)
+entity = testUser.newExperiment(testName)
+protocol = protocolWithElements(testUser)
 exp_protocol = entity.addProtocol(protocol)
 entity = testUser.getExperiment(entity.id)
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,20 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import labstep
+from fixtures import experiment, protocol, user, testString
 
-from fixtures import protocolWithElements
-
-testUser = labstep.login('apitest@labstep.com', 'apitestpass')
-
-# Set variables
-testName = labstep.helpers.getTime()
 
 # Make new entity
-entity = testUser.newExperiment(testName)
-protocol = protocolWithElements(testUser)
+entity = experiment()
+protocol = protocol()
 exp_protocol = entity.addProtocol(protocol)
-entity = testUser.getExperiment(entity.id)
+entity = user.getExperiment(entity.id)
 
 
 class TestExperiment:
@@ -44,13 +38,13 @@ class TestExperiment:
             'FAILED TO EDIT EXPERIMENT'
 
     def test_delete(self):
-        entityToDelete = testUser.newExperiment(testName)
+        entityToDelete = user.newExperiment(testString)
         result = entityToDelete.delete()
         assert result.deleted_at is not None, \
             'FAILED TO DELETE EXPERIMENT'
 
     def test_addProtocol(self):
-        get_protocol = testUser.newProtocol('Test')
+        get_protocol = user.newProtocol('Test')
         result = entity.addProtocol(get_protocol)
         assert result is not None, \
             'FAILED TO ADD PROTOCOL TO EXPERIMENT'
@@ -61,12 +55,12 @@ class TestExperiment:
             'FAILED TO GET PROTOCOLS'
 
     def test_addComment(self):
-        result = entity.addComment(testName, './tests/test_experiment.py')
+        result = entity.addComment(testString, './tests/test_experiment.py')
         assert result is not None, \
             'FAILED TO ADD COMMENT AND FILE'
 
     def test_addTag(self):
-        result = entity.addTag(testName)
+        result = entity.addTag(testString)
         assert result is not None, \
             'FAILED TO ADD TAG'
 
@@ -100,12 +94,12 @@ class TestExperiment:
 
     def test_addDataElementTo(self):
         entity.addDataElement('testField', fieldType="default",)
-        newEntity = testUser.getExperiment(entity.id)
+        newEntity = user.getExperiment(entity.id)
         dataElements = newEntity.getDataElements()
         assert len(dataElements) == 1
 
     def test_addMaterial(self):
-        resource = testUser.newResource('test')
+        resource = user.newResource('test')
         resource_item = resource.newItem('test')
         entity.addMaterial('testMaterial',
                            amount=10,

--- a/tests/test_experiment_protocol.py
+++ b/tests/test_experiment_protocol.py
@@ -3,17 +3,15 @@
 
 import labstep
 
+from fixtures import experimentProtocol
+
 testUser = labstep.login('apitest@labstep.com', 'apitestpass')
 
 # Set variables
 testName = labstep.helpers.getTime()
 
 # Make new entity
-new_entity = testUser.newExperiment(testName)
-entity = testUser.getExperiment(new_entity.id)
-protocol = testUser.newProtocol('Test')
-protocol = testUser.getProtocol(protocol.id)
-experiment_protocol = entity.addProtocol(protocol)
+experiment_protocol = experimentProtocol(testUser)
 
 
 class TestExperimentProtocol:
@@ -27,29 +25,21 @@ class TestExperimentProtocol:
         assert len(dataElements) == 0
 
     def test_addDataElementTo(self):
-        experiment_protocol.addDataElement(
+        result = experiment_protocol.addDataElement(
             fieldType="default", fieldName="test")
-        newEntity = testUser.getExperiment(entity.id)
-        experiment_protocols = newEntity.getProtocols()
-        assert len(experiment_protocols) == 1
-        refreshed_experiment_protocol = experiment_protocols[0]
-        dataElements = refreshed_experiment_protocol.getDataElements()
-        assert len(dataElements) == 1
+        assert result.label == 'test'
 
     def test_addMaterial(self):
         resource = testUser.newResource('test')
-        resource_item = resource.newItem('test')
-        experiment_protocol.addMaterial('testMaterial',
-                                        amount=10,
-                                        units='uL',
-                                        resource_id=resource.id,
-                                        resource_item_id=resource_item.id)
+        item = resource.newItem('test')
+        material = experiment_protocol.addMaterial('testMaterial',
+                                                   amount=10,
+                                                   units='uL',
+                                                   resource_id=resource.id,
+                                                   resource_item_id=item.id)
 
-        updated_exp = testUser.getExperiment(new_entity.id)
-        updated_exp_protocol = updated_exp.getProtocols()[0]
-        material = updated_exp_protocol.getMaterials()[0]
         assert material.name == 'testMaterial' \
             and material.amount == '10' \
             and material.units == 'uL' \
             and material.resource['id'] == resource.id \
-            and material.resource_item['id'] == resource_item.id
+            and material.resource_item['id'] == item.id

--- a/tests/test_experiment_protocol.py
+++ b/tests/test_experiment_protocol.py
@@ -36,8 +36,12 @@ class TestExperimentProtocol:
             and material.units == 'uL' \
             and material.resource['id'] == resource.id \
             and material.resource_item['id'] == item.id
-
     # ExperimentStep
+
+    def test_addSteps(self):
+        result = experiment_protocol.addSteps(2)
+        assert len(result) == 2
+
     def test_getSteps(self):
         result = experiment_protocol.getSteps()
         assert result[0].id is not None, \

--- a/tests/test_experiment_protocol.py
+++ b/tests/test_experiment_protocol.py
@@ -4,7 +4,7 @@
 from fixtures import user, experimentProtocol
 
 # Make new entity
-experiment_protocol = experimentProtocol(user)
+experiment_protocol = experimentProtocol()
 
 
 class TestExperimentProtocol:
@@ -36,3 +36,15 @@ class TestExperimentProtocol:
             and material.units == 'uL' \
             and material.resource['id'] == resource.id \
             and material.resource_item['id'] == item.id
+
+    # ExperimentStep
+    def test_getSteps(self):
+        result = experiment_protocol.getSteps()
+        assert result[0].id is not None, \
+            'FAILED TO GET STEPS'
+
+    def test_completeStep(self):
+        steps = experiment_protocol.getSteps()
+        result = steps[0].complete()
+        assert result.ended_at is not None, \
+            'FAILED TO COMPLETE STEP'

--- a/tests/test_experiment_protocol.py
+++ b/tests/test_experiment_protocol.py
@@ -1,17 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import labstep
-
-from fixtures import experimentProtocol
-
-testUser = labstep.login('apitest@labstep.com', 'apitestpass')
-
-# Set variables
-testName = labstep.helpers.getTime()
+from fixtures import user, experimentProtocol
 
 # Make new entity
-experiment_protocol = experimentProtocol(testUser)
+experiment_protocol = experimentProtocol(user)
 
 
 class TestExperimentProtocol:
@@ -30,7 +23,7 @@ class TestExperimentProtocol:
         assert result.label == 'test'
 
     def test_addMaterial(self):
-        resource = testUser.newResource('test')
+        resource = user.newResource('test')
         item = resource.newItem('test')
         material = experiment_protocol.addMaterial('testMaterial',
                                                    amount=10,

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,16 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
-import labstep
-
-testUser = labstep.login('apitest@labstep.com', 'apitestpass')
-
-# Set variables
-testName = labstep.helpers.getTime()
+from fixtures import resource, testString
 
 # Make new entity
-new_entity = testUser.newResource(testName)
-entity = new_entity.addMetadata(fieldName=testName, value=testName)
+new_entity = resource()
+entity = new_entity.addMetadata(fieldName=testString, value=testString)
 
 
 class TestMetadata:

--- a/tests/test_order_request.py
+++ b/tests/test_order_request.py
@@ -1,19 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import labstep
-
-testUser = labstep.login('apitest@labstep.com', 'apitestpass')
-
-# Set variables
-testName = labstep.helpers.getTime()
+from fixtures import user, orderRequest, testString
 
 # Make new entity
-new_resource = testUser.newResource(testName)
-new_entity = new_resource.newOrderRequest()
-entity = testUser.getOrderRequest(new_entity.id)
-entity.addMetadata(fieldName='test', value=testName)
-entity.addComment(testName)
+entity = orderRequest()
 
 
 class TestOrderRequest:
@@ -23,7 +14,7 @@ class TestOrderRequest:
             'FAILED TO EDIT ORDER REQUEST'
 
     def test_delete(self):
-        test_resource = testUser.newResource('testDelete')
+        test_resource = user.newResource('testDelete')
         entityToDelete = test_resource.newOrderRequest()
         result = entityToDelete.delete()
         assert result.deleted_at is not None, \
@@ -31,11 +22,11 @@ class TestOrderRequest:
 
     def test_getResource(self):
         result = entity.getResource()
-        assert result.id == new_resource.id, \
-            'FAILED TO GET METADATA'
+        assert result.id is not None, \
+            'FAILED TO GET RESOURCE'
 
     def test_addComment(self):
-        result = entity.addComment(testName, './tests/test_order_request.py')
+        result = entity.addComment(testString, './tests/test_order_request.py')
         assert result is not None, \
             'FAILED TO ADD COMMENT AND FILE'
 
@@ -45,7 +36,7 @@ class TestOrderRequest:
             'FAILED TO GET COMMENTS'
 
     def test_addTag(self):
-        result = entity.addTag(testName)
+        result = entity.addTag(testString)
         assert result is not None, \
             'FAILED TO ADD TAG'
 
@@ -55,8 +46,8 @@ class TestOrderRequest:
             'FAILED TO GET TAGS'
 
     def test_addMetadata(self):
-        result = entity.addMetadata(fieldName=testName, value=testName)
-        assert result.label == testName, \
+        result = entity.addMetadata(fieldName=testString, value=testString)
+        assert result.label == testString, \
             'FAILED TO ADD METADATA'
 
     def test_getMetadata(self):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,14 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+from fixtures import user, protocol, tableData, testString, contentStateEmpty
 
-import labstep
-
-from fixtures import protocolWithElements, tableData, contentStateEmpty
-
-testUser = labstep.login('apitest@labstep.com', 'apitestpass')
-testName = labstep.helpers.getTime()
-
-entity = protocolWithElements(testUser)
+entity = protocol()
 
 
 class TestProtocol:
@@ -18,13 +12,13 @@ class TestProtocol:
             'FAILED TO EDIT PROTOCOL'
 
     def test_delete(self):
-        entityToDelete = testUser.newProtocol(testName)
+        entityToDelete = user.newProtocol(testString)
         result = entityToDelete.delete()
         assert result.deleted_at is not None,\
             'FAILED TO DELETE PROTOCOL'
 
     def test_addComment(self):
-        result = entity.addComment(testName, './tests/test_protocol.py')
+        result = entity.addComment(testString, './tests/test_protocol.py')
         assert result is not None,\
             'FAILED TO ADD COMMENT AND FILE'
 
@@ -34,7 +28,7 @@ class TestProtocol:
             'FAILED TO GET COMMENTS'
 
     def test_addTag(self):
-        result = entity.addTag(testName)
+        result = entity.addTag(testString)
         assert result is not None,\
             'FAILED TO ADD TAG'
 
@@ -53,7 +47,7 @@ class TestProtocol:
             'FAILED TO GET STEPS'
 
     def test_addMaterial(self):
-        result = entity.addMaterial(name=testName, amount='2.0', units='ml')
+        result = entity.addMaterial(name=testString, amount='2.0', units='ml')
         assert result is not None,\
             'FAILED TO ADD MATERIAL'
 
@@ -69,7 +63,7 @@ class TestProtocol:
             'FAILED TO EDIT MATERIAL'
 
     def test_addTimer(self):
-        result = entity.addTimer(name=testName, minutes=20, seconds=30)
+        result = entity.addTimer(name=testString, minutes=20, seconds=30)
         assert result is not None,\
             'FAILED TO ADD TIMER'
 
@@ -85,7 +79,7 @@ class TestProtocol:
             'FAILED TO EDIT TIMER'
 
     def test_addTable(self):
-        result = entity.addTable(name=testName, data=tableData)
+        result = entity.addTable(name=testString, data=tableData)
         assert result is not None,\
             'FAILED TO ADD TABLE'
 
@@ -96,8 +90,8 @@ class TestProtocol:
 
     def test_editTable(self):
         table = entity.getTables()[0]
-        result = table.edit(name=testName)
-        assert result.name == testName,\
+        result = table.edit(name=testString)
+        assert result.name == testString,\
             'FAILED TO EDIT TABLE'
 
     def test_getDataElements(self):
@@ -106,7 +100,7 @@ class TestProtocol:
 
     def test_addDataElement(self):
         entity.addDataElement(fieldType="default", fieldName="test")
-        newEntity = testUser.getProtocol(entity.id)
+        newEntity = user.getProtocol(entity.id)
         dataElements = newEntity.getDataElements()
         assert len(dataElements) == 1
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -3,66 +3,12 @@
 
 import labstep
 
-testUser = labstep.login('apitest@labstep.com', 'apitestpass')
+from fixtures import protocolWithElements, tableData, contentStateEmpty
 
-# Set variables
+testUser = labstep.login('apitest@labstep.com', 'apitestpass')
 testName = labstep.helpers.getTime()
 
-# Make new entity
-new_entity = testUser.newProtocol(testName)
-entity = testUser.getProtocol(new_entity.id)
-entity.addComment(testName)
-entity.addMaterial(testName, amount='0.1', units='ml')
-entity.addTimer(name=testName, hours=4, minutes=15)
-
-data = {
-    "rowCount": 6,
-    "columnCount": 6,
-    "colHeaderData": {},
-    "data": {
-        "dataTable": {
-            0: {
-                0: {
-                    "value": 'Cell A1'
-                },
-                1: {
-                    "value": 'Cell B1'
-                }
-            }
-        }
-    }
-}
-result = entity.addTable(name=testName, data=data)
-
-entity = testUser.getProtocol(entity.id)
-
-content_state = {
-    "object": "value",
-    "document": {
-        "object": "document",
-        "data": [],
-        "nodes": [
-            {
-                "object": "block",
-                "type": "paragraph",
-                "isVoid": False,
-                "data": [],
-                "nodes": [
-                    {
-                        "object": "text",
-                        "leaves": [
-                            {
-                                "object": "leaf",
-                                "text": " ",
-                                "marks": []
-                            }
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
-}
+entity = protocolWithElements(testUser)
 
 
 class TestProtocol:
@@ -96,6 +42,10 @@ class TestProtocol:
         result = entity.getTags()
         assert result[0].id is not None,\
             'FAILED TO GET TAGS'
+
+    def test_addSteps(self):
+        result = entity.addSteps(2)
+        assert len(result) == 2
 
     def test_getSteps(self):
         result = entity.getSteps()
@@ -135,7 +85,7 @@ class TestProtocol:
             'FAILED TO EDIT TIMER'
 
     def test_addTable(self):
-        result = entity.addTable(name=testName, data=data)
+        result = entity.addTable(name=testName, data=tableData)
         assert result is not None,\
             'FAILED TO ADD TABLE'
 
@@ -161,8 +111,8 @@ class TestProtocol:
         assert len(dataElements) == 1
 
     def test_edit_content_state(self):
-        result = entity.edit(content_state=content_state)
-        assert result.last_version['content_state'] == content_state,\
+        result = entity.edit(name='updated', content_state=contentStateEmpty)
+        assert result.last_version['content_state'] == contentStateEmpty,\
             'FAILED TO EDIT PROTOCOL CONTENT STATE'
 
     def test_new_version(self):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -51,8 +51,9 @@ class TestResource:
 
     def test_setResourceCategory(self):
         my_resourceCategory = user.getResourceCategorys()[0]
-        result = entity.setResourceCategory(my_resourceCategory.id)
-        assert result.resource_category is not None, \
+        entity.setResourceCategory(my_resourceCategory.id)
+        entity.update()
+        assert entity.resource_category is not None, \
             'FAILED TO ADD METADATA'
 
     def test_newOrderRequest(self):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -14,8 +14,6 @@ entity = testUser.getResource(new_entity.id)
 entity.addMetadata(fieldName='test', value=testName)
 entity.addComment(testName)
 
-my_resourceCategory = testUser.getResourceCategorys()[0]
-esult = entity.setResourceCategory(my_resourceCategory.id)
 
 class TestResource:
     def test_edit(self):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,18 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import labstep
-
-testUser = labstep.login('apitest@labstep.com', 'apitestpass')
-
-# Set variables
-testName = labstep.helpers.getTime()
+from fixtures import user, resource, testString
 
 # Make new entity
-new_entity = testUser.newResource(testName)
-entity = testUser.getResource(new_entity.id)
-entity.addMetadata(fieldName='test', value=testName)
-entity.addComment(testName)
+entity = resource(user)
 
 
 class TestResource:
@@ -22,13 +14,13 @@ class TestResource:
             'FAILED TO EDIT RESOURCE'
 
     def test_delete(self):
-        entityToDelete = testUser.newResource('testDelete')
+        entityToDelete = user.newResource('testDelete')
         result = entityToDelete.delete()
         assert result.deleted_at is not None, \
             'FAILED TO DELETE RESOURCE'
 
     def test_addComment(self):
-        result = entity.addComment(testName, './tests/test_resource.py')
+        result = entity.addComment(testString, './tests/test_resource.py')
         assert result is not None, \
             'FAILED TO ADD COMMENT AND FILE'
 
@@ -38,7 +30,7 @@ class TestResource:
             'FAILED TO GET COMMENTS'
 
     def test_addTag(self):
-        result = entity.addTag(testName)
+        result = entity.addTag(testString)
         assert result is not None, \
             'FAILED TO ADD TAG'
 
@@ -48,8 +40,8 @@ class TestResource:
             'FAILED TO GET TAGS'
 
     def test_addMetadata(self):
-        result = entity.addMetadata(fieldName=testName, value=testName)
-        assert result.label == testName, \
+        result = entity.addMetadata(fieldName=testString, value=testString)
+        assert result.label == testString, \
             'FAILED TO ADD METADATA'
 
     def test_getMetadata(self):
@@ -58,7 +50,7 @@ class TestResource:
             'FAILED TO GET METADATA'
 
     def test_setResourceCategory(self):
-        my_resourceCategory = testUser.getResourceCategorys()[0]
+        my_resourceCategory = user.getResourceCategorys()[0]
         result = entity.setResourceCategory(my_resourceCategory.id)
         assert result.resource_category is not None, \
             'FAILED TO ADD METADATA'
@@ -69,7 +61,7 @@ class TestResource:
             'FAILED TO MAKE NEW ORDER REQUEST'
 
     def test_newItem(self):
-        result = entity.newItem(name=testName)
+        result = entity.newItem(name=testString)
         assert result.id, \
             'FAILED TO MAKE NEW ITEM'
 

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -4,7 +4,7 @@
 from fixtures import user, resource, testString
 
 # Make new entity
-entity = resource(user)
+entity = resource()
 
 
 class TestResource:

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -14,6 +14,8 @@ entity = testUser.getResource(new_entity.id)
 entity.addMetadata(fieldName='test', value=testName)
 entity.addComment(testName)
 
+my_resourceCategory = testUser.getResourceCategorys()[0]
+esult = entity.setResourceCategory(my_resourceCategory.id)
 
 class TestResource:
     def test_edit(self):

--- a/tests/test_resource_category.py
+++ b/tests/test_resource_category.py
@@ -2,18 +2,9 @@
 # -*- coding: utf-8 -*-
 # pylama:ignore=E501
 
-import labstep
+from fixtures import user, resourceCategory, testString
 
-testUser = labstep.login('apitest@labstep.com', 'apitestpass')
-
-# Set variables
-testName = labstep.helpers.getTime()
-
-# Make new entity
-new_entity = testUser.newResourceCategory(testName)
-entity = testUser.getResourceCategory(new_entity.id)
-entity.addMetadata(fieldName='test', value=testName)
-entity.addComment(testName)
+entity = resourceCategory()
 
 
 class TestResourceCategory:
@@ -23,13 +14,13 @@ class TestResourceCategory:
             'FAILED TO EDIT RESOURCE CATEGORY'
 
     def test_delete(self):
-        entityToDelete = testUser.newResourceCategory('testDelete')
+        entityToDelete = user.newResourceCategory('testDelete')
         result = entityToDelete.delete()
         assert result.deleted_at is not None, \
             'FAILED TO DELETE RESOURCE CATEGORY'
 
     def test_addComment(self):
-        result = entity.addComment(testName, './tests/test_resource_category.py')
+        result = entity.addComment(testString, './tests/test_resource_category.py')
         assert result is not None, \
             'FAILED TO ADD COMMENT AND FILE'
 
@@ -39,7 +30,7 @@ class TestResourceCategory:
             'FAILED TO GET COMMENTS'
 
     def test_addTag(self):
-        result = entity.addTag(testName)
+        result = entity.addTag(testString)
         assert result is not None, \
             'FAILED TO ADD TAG'
 
@@ -49,10 +40,10 @@ class TestResourceCategory:
             'FAILED TO GET TAGS'
 
     def test_addMetadata(self):
-        new_resource_category = testUser.newResourceCategory(testName)
-        result = new_resource_category.addMetadata(fieldName=testName,
-                                                   value=testName)
-        assert result.label == testName, \
+        new_resource_category = user.newResourceCategory(testString)
+        result = new_resource_category.addMetadata(fieldName=testString,
+                                                   value=testString)
+        assert result.label == testString, \
             'FAILED TO ADD METADATA'
 
     def test_getMetadata(self):

--- a/tests/test_resource_item.py
+++ b/tests/test_resource_item.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from fixtures import user, testString, resource, resourceItem
+from fixtures import testString, resource, resourceItem
 
 # Make new entity
 entity = resourceItem()

--- a/tests/test_resource_item.py
+++ b/tests/test_resource_item.py
@@ -1,18 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import labstep
-
-testUser = labstep.login('apitest@labstep.com', 'apitestpass')
-
-# Set variables
-testName = labstep.helpers.getTime()
+from fixtures import user, testString, resource, resourceItem
 
 # Make new entity
-resource = testUser.newResource(testName)
-entity = resource.newItem(name='Pytest Acetone')
-entity.addMetadata(fieldName='test', value=testName)
-entity.addComment(testName)
+entity = resourceItem()
 
 
 class TestResource:
@@ -22,13 +14,13 @@ class TestResource:
             'FAILED TO EDIT RESOURCE ITEM'
 
     def test_delete(self):
-        entityToDelete = resource.newItem('testDelete')
+        entityToDelete = resource().newItem('testDelete')
         result = entityToDelete.delete()
         assert result.deleted_at is not None, \
             'FAILED TO DELETE RESOURCE ITEM'
 
     def test_addComment(self):
-        result = entity.addComment(testName, './tests/test_resource.py')
+        result = entity.addComment(testString, './tests/test_resource.py')
         assert result is not None, \
             'FAILED TO ADD COMMENT AND FILE'
 
@@ -38,8 +30,8 @@ class TestResource:
             'FAILED TO GET COMMENTS'
 
     def test_addMetadata(self):
-        result = entity.addMetadata(fieldName=testName, value=testName)
-        assert result.label == testName, \
+        result = entity.addMetadata(fieldName=testString, value=testString)
+        assert result.label == testString, \
             'FAILED TO ADD METADATA'
 
     def test_getMetadata(self):

--- a/tests/test_resource_location.py
+++ b/tests/test_resource_location.py
@@ -1,26 +1,20 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import labstep
+from fixtures import user, resourceLocation, testString, newString
 
-testUser = labstep.login('apitest@labstep.com', 'apitestpass')
-
-# Set variables
-testName = labstep.helpers.getTime()
-
+entity = resourceLocation()
 
 class TestResourceLocation:
     def test_edit(self):
-        entity = testUser.newResourceLocation(testName)
-        newName = labstep.helpers.getTime()
+        newName = newString()
         result = entity.edit(newName)
         result.delete()
         assert result.name == newName, \
             'FAILED TO EDIT RESOURCE LOCATION'
 
     def test_delete(self):
-        testName = labstep.helpers.getTime()
-        entityToDelete = testUser.newResourceLocation(testName)
+        entityToDelete = user.newResourceLocation(newString())
         result = entityToDelete.delete()
         assert result is None, \
             'FAILED TO DELETE RESOURCE LOCATION'

--- a/tests/test_resource_location.py
+++ b/tests/test_resource_location.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from fixtures import user, resourceLocation, testString, newString
+from fixtures import user, resourceLocation, newString
 
 entity = resourceLocation()
+
 
 class TestResourceLocation:
     def test_edit(self):

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -5,6 +5,8 @@ from fixtures import (workspace, experiment, protocol,
                       resource, resourceCategory, orderRequest)
 # Make new entity
 
+workspace = workspace()
+
 
 class TestSharing:
     def test_share_experiment(self):

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -1,20 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import labstep
-
-testUser = labstep.login('apitest@labstep.com', 'apitestpass')
-
-# Set variables
-testName = labstep.helpers.getTime()
-
+from fixtures import (workspace, experiment, protocol,
+                      resource, resourceCategory, orderRequest)
 # Make new entity
-workspace = testUser.newWorkspace(testName)
 
 
 class TestSharing:
     def test_share_experiment(self):
-        entity = testUser.newExperiment(testName)
+        entity = experiment()
         entity.shareWith(workspace.id, 'view')
         permission = entity.getPermissions()[0]
         permission.set('edit')
@@ -27,7 +21,7 @@ class TestSharing:
             'FAILED TO SHARE EXPERIMENT'
 
     def test_share_protocol(self):
-        entity = testUser.newProtocol(testName)
+        entity = protocol()
         entity.shareWith(workspace.id, 'view')
         permission = entity.getPermissions()[0]
         permission.set('edit')
@@ -40,7 +34,7 @@ class TestSharing:
             'FAILED TO SHARE PROTOCOL'
 
     def test_share_resource(self):
-        entity = testUser.newResource(testName)
+        entity = resource()
         entity.shareWith(workspace.id, 'view')
         permission = entity.getPermissions()[0]
         permission.set('edit')
@@ -53,7 +47,7 @@ class TestSharing:
             'FAILED TO SHARE RESOURCE'
 
     def test_share_resourceCategory(self):
-        entity = testUser.newResourceCategory(testName)
+        entity = resourceCategory()
         entity.shareWith(workspace.id, 'view')
         permission = entity.getPermissions()[0]
         permission.set('edit')
@@ -66,7 +60,7 @@ class TestSharing:
             'FAILED TO SHARE RESOURCE CATEGORY'
 
     def test_share_orderRequest(self):
-        entity = testUser.newResource(testName).newOrderRequest()
+        entity = orderRequest()
         entity.shareWith(workspace.id, 'view')
         permission = entity.getPermissions()[0]
         permission.set('edit')

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -1,26 +1,20 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import labstep
-
-testUser = labstep.login('apitest@labstep.com', 'apitestpass')
-
-# Set variables
-testName = labstep.helpers.getTime()
+from fixtures import user, newString
 
 
 class TestTag:
     def test_edit(self):
-        entity = testUser.newTag(testName, 'experiment_workflow')
-        newName = labstep.helpers.getTime()
+        entity = user.newTag(newString(), 'experiment_workflow')
+        newName = newString()
         result = entity.edit(newName)
         result.delete()
         assert result.name == newName, \
             'FAILED TO EDIT TAG NAME'
 
     def test_delete(self):
-        testName = labstep.helpers.getTime()
-        entityToDelete = testUser.newTag(testName, 'experiment_workflow')
+        entityToDelete = user.newTag(newString(), 'experiment_workflow')
         result = entityToDelete.delete()
         assert result is None, \
             'FAILED TO DELETE TAG'

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -3,179 +3,175 @@
 
 import labstep
 
-testUser = labstep.login('apitest@labstep.com',
-                         'apitestpass')
-
-# Set variables
-testName = labstep.helpers.getTime()
+from fixtures import user, testString
 
 
-class TestUser:
+class User:
     def test_login(self):
-        testUser = labstep.login('apitest@labstep.com', 'apitestpass')
-        assert testUser.id == 8400, \
+        user = labstep.login('apitest@labstep.com', 'apitestpass')
+        assert user.id == 8400, \
             'FAILED TO LOGIN'
 
     def test_authenticate(self):
-        testUser = labstep.authenticate(
+        user = labstep.authenticate(
             'apitest@labstep.com', '1c5b51d1-a1a5-4661-9eea-f71b7523f909')
-        assert testUser.id == 8400, \
+        assert user.id == 8400, \
             'FAILED TO AUTHENTICATE'
 
     def test_setWorkspace(self):
-        my_workspace = testUser.getWorkspace(11339)
-        testUser.setWorkspace(my_workspace.id)
-        my_experiment = testUser.newExperiment('Test')
+        my_workspace = user.getWorkspace(11339)
+        user.setWorkspace(my_workspace.id)
+        my_experiment = user.newExperiment('Test')
         workspace_experiments = my_workspace.getExperiments()
         assert workspace_experiments[0].id == my_experiment.id, \
             'FAILED TO SET WORKSPACE'
 
     # getSingle()
     def test_getExperiment(self):
-        entity = testUser.newExperiment(testName)
-        result = testUser.getExperiment(entity.id)
-        assert result.name == testName, \
+        entity = user.newExperiment(testString)
+        result = user.getExperiment(entity.id)
+        assert result.name == testString, \
             'FAILED TO GET EXPERIMENT'
 
     def test_getProtocol(self):
-        entity = testUser.newProtocol(testName)
-        result = testUser.getProtocol(entity.id)
-        assert result.name == testName, \
+        entity = user.newProtocol(testString)
+        result = user.getProtocol(entity.id)
+        assert result.name == testString, \
             'FAILED TO GET PROTOCOL'
 
     def test_getResource(self):
-        entity = testUser.newResource(testName)
-        result = testUser.getResource(entity.id)
-        assert result.name == testName, \
+        entity = user.newResource(testString)
+        result = user.getResource(entity.id)
+        assert result.name == testString, \
             'FAILED TO GET RESOURCE'
 
     def test_getResourceLocation(self):
-        entity = testUser.newResourceLocation(testName)
-        result = testUser.getResourceLocation(entity.id)
-        assert result.name == testName, \
+        entity = user.newResourceLocation(testString)
+        result = user.getResourceLocation(entity.id)
+        assert result.name == testString, \
             'FAILED TO GET RESOURCE LOCATION'
 
     def test_getResourceCategory(self):
-        entity = testUser.newResourceCategory(testName)
-        result = testUser.getResourceCategory(entity.id)
-        assert result.name == testName, \
+        entity = user.newResourceCategory(testString)
+        result = user.getResourceCategory(entity.id)
+        assert result.name == testString, \
             'FAILED TO GET RESOURCE CATEGORY'
 
     def test_getOrderRequest(self):
-        new_resource = testUser.newResource(testName)
-        entity = testUser.newOrderRequest(resource_id=new_resource.id)
-        result = testUser.getOrderRequest(entity.id)
-        assert result.name == testName, \
+        new_resource = user.newResource(testString)
+        entity = user.newOrderRequest(resource_id=new_resource.id)
+        result = user.getOrderRequest(entity.id)
+        assert result.name == testString, \
             'FAILED TO GET ORDER REQUEST'
 
     def test_getWorkspace(self):
-        entity = testUser.newWorkspace(testName)
-        result = testUser.getWorkspace(entity.id)
-        assert result.name == testName, \
+        entity = user.newWorkspace(testString)
+        result = user.getWorkspace(entity.id)
+        assert result.name == testString, \
             'FAILED TO GET WORKSPACE'
 
     def test_getFile(self):
-        entity = testUser.newFile('./tests/test_user.py')
-        result = testUser.getFile(entity.id)
+        entity = user.newFile('./tests/test_user.py')
+        result = user.getFile(entity.id)
         assert result.id == entity.id, \
             'FAILED TO GET FILE'
 
     # getMany()
     def test_getExperiments(self):
-        result = testUser.getExperiments()
+        result = user.getExperiments()
         assert result[0].id, \
             'FAILED TO GET EXPERIMENTS'
 
     def test_getProtocols(self):
-        result = testUser.getProtocols()
+        result = user.getProtocols()
         assert result[0].id, \
             'FAILED TO GET PROTOCOLS'
 
     def test_getResources(self):
-        result = testUser.getResources()
+        result = user.getResources()
         assert result[0].id, \
             'FAILED TO GET RESOURCES'
 
     def test_getResourceCategorys(self):
-        result = testUser.getResourceCategorys()
+        result = user.getResourceCategorys()
         assert result[0].id, \
             'FAILED TO GET RESOURCE CATEGORYS'
 
     def test_getResourceLocations(self):
-        result = testUser.getResourceLocations()
+        result = user.getResourceLocations()
         assert result[0].id, \
             'FAILED TO GET RESOURCE LOCATIONS'
 
     def test_getOrderRequests(self):
-        result = testUser.getOrderRequests()
+        result = user.getOrderRequests()
         assert result[0].id, \
             'FAILED TO GET ORDER REQUESTS'
 
     def test_getOrderRequestsWithFilter(self):
-        result = testUser.getOrderRequests(status='new')
+        result = user.getOrderRequests(status='new')
         assert result[0].id, \
             'FAILED TO GET ORDER REQUESTS WITH FILTER'
 
     def test_getTags(self):
-        result = testUser.getTags()
+        result = user.getTags()
         assert result[0].id, \
             'FAILED TO GET TAGS'
 
     def test_getWorkspaces(self):
-        result = testUser.getWorkspaces()
+        result = user.getWorkspaces()
         assert result[0].id, \
             'FAILED TO GET WORKSPACES'
 
     def test_getFiles(self):
-        result = testUser.getFiles()
+        result = user.getFiles()
         assert result[0].id, \
             'FAILED TO GET FILES'
 
     # newEntity()
     def test_newExperiment(self):
-        result = testUser.newExperiment(testName)
-        assert result.name == testName, \
+        result = user.newExperiment(testString)
+        assert result.name == testString, \
             'FAILED TO CREATE NEW EXPERIMENT'
 
     def test_newProtocol(self):
-        result = testUser.newProtocol(testName)
-        assert result.name == testName, \
+        result = user.newProtocol(testString)
+        assert result.name == testString, \
             'FAILED TO CREATE NEW PROTOCOL'
 
     def test_newResource(self):
-        result = testUser.newResource(testName)
-        assert result.name == testName, \
+        result = user.newResource(testString)
+        assert result.name == testString, \
             'FAILED TO CREATE NEW RESOURCE'
 
     def test_newResourceCategory(self):
-        result = testUser.newResourceCategory(testName)
-        assert result.name == testName, \
+        result = user.newResourceCategory(testString)
+        assert result.name == testString, \
             'FAILED TO CREATE NEW RESOURCE CATEGORY'
 
     def test_newResourceLocation(self):
-        result = testUser.newResourceLocation('testLocation')
+        result = user.newResourceLocation('testLocation')
         result.delete()
         assert result.name == 'testLocation', \
             'FAILED TO CREATE NEW RESOURCE LOCATION'
 
     def test_newOrderRequest(self):
-        entity = testUser.newResource(testName)
-        result = testUser.newOrderRequest(resource_id=entity.id)
-        assert result.name == testName, \
+        entity = user.newResource(testString)
+        result = user.newOrderRequest(resource_id=entity.id)
+        assert result.name == testString, \
             'FAILED TO CREATE NEW ORDER REQUEST'
 
     def test_newTag(self):
-        result = testUser.newTag('test_newTag', type='experiment_workflow')
+        result = user.newTag('test_newTag', type='experiment_workflow')
         result.delete()
         assert result.name == 'test_newTag', \
             'FAILED TO CREATE NEW TAG'
 
     def test_newWorkspace(self):
-        result = testUser.newWorkspace(testName)
-        assert result.name == testName, \
+        result = user.newWorkspace(testString)
+        assert result.name == testString, \
             'FAILED TO CREATE NEW WORKSPACE'
 
     def test_newFile(self):
-        result = testUser.newFile('./tests/test_user.py')
+        result = user.newFile('./tests/test_user.py')
         assert result is not None, \
             'FAILED TO ADD NEW FILE'

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,17 +1,12 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import labstep
-
-testUser = labstep.login('apitest@labstep.com', 'apitestpass')
-
-# Set variables
-testName = labstep.helpers.getTime()
+from fixtures import user, workspace, testString
 
 # Make new entity
-new_entity = testUser.newWorkspace(testName)
-entity = testUser.getWorkspace(new_entity.id)
-testUser.setWorkspace(entity.id)
+entity = workspace()
+
+user.setWorkspace(entity.id)
 
 
 class TestWorkspace:
@@ -21,52 +16,52 @@ class TestWorkspace:
             'FAILED TO EDIT WORKSPACE'
 
     def test_delete(self):
-        entityToDelete = testUser.newWorkspace(testName)
+        entityToDelete = user.newWorkspace(testString)
         result = entityToDelete.delete()
         assert result.deleted_at is not None, \
             'FAILED TO DELETE WORKSPACE'
 
     # getMany()
     def test_getExperiments(self):
-        testUser.newExperiment(testName)
+        user.newExperiment(testString)
         result = entity.getExperiments()
         assert result[0].id, \
             'FAILED TO GET EXPERIMENTS'
 
     def test_getProtocols(self):
-        testUser.newProtocol(testName)
+        user.newProtocol(testString)
         result = entity.getProtocols()
         assert result[0].id, \
             'FAILED TO GET PROTOCOLS'
 
     def test_getResources(self):
-        testUser.newResource(testName)
+        user.newResource(testString)
         result = entity.getResources()
         assert result[0].id, \
             'FAILED TO GET RESOURCES'
 
     def test_getResourceCategorys(self):
-        testUser.newResourceCategory(testName)
+        user.newResourceCategory(testString)
         result = entity.getResourceCategorys()
         assert result[0].id, \
             'FAILED TO GET RESOURCE CATEGORYS'
 
     def test_getResourceLocations(self):
-        new_RL = testUser.newResourceLocation(testName)
+        new_RL = user.newResourceLocation(testString)
         result = entity.getResourceLocations()
         new_RL.delete()
         assert result[0].id, \
             'FAILED TO GET RESOURCE LOCATIONS'
 
     def test_getOrderRequests(self):
-        new_resource = testUser.newResource(testName)
+        new_resource = user.newResource(testString)
         new_resource.newOrderRequest()
         result = entity.getOrderRequests()
         assert result[0].id, \
             'FAILED TO GET ORDER REQUESTS'
 
     def test_getTags(self):
-        new_tag = testUser.newTag('test_newTag', type='experiment_workflow')
+        new_tag = user.newTag('test_newTag', type='experiment_workflow')
         result = entity.getTags()
         new_tag.delete()
         assert result[0].id, \


### PR DESCRIPTION
- `newExperiment` and `editExperiment` methods now use parameter `entry` instead of `description` to match change on the web app.

- Generic method `newEntities` for `batch` entity creation endpoints.

- More robust `entity.update()` now calls `__init__`

- Adding / getting Materials and Data elements now on `root_experiment`

- new method `addSteps` for `Protocol` and `ExperimentProtocol`

- refactored tests