### PR TITLE
Resource Item Templates Feature

### DIFF
--- a/labstep/entity.py
+++ b/labstep/entity.py
@@ -127,7 +127,10 @@ def newEntity(user, entityClass, fields):
     url = url_join(API_ROOT, "/api/generic/", entityClass.__entityName__)
     fields = dict(
         filter(lambda field: field[1] is not None, fields.items()))
-    fields['group_id'] = user.activeWorkspace
+
+    if getattr(entityClass, '__hasParentGroup__', False):
+        fields['group_id'] = user.activeWorkspace
+
     r = requests.post(url, headers=headers, json=fields)
     handleError(r)
     return entityClass(json.loads(r.content), user)

--- a/labstep/primaryEntity.py
+++ b/labstep/primaryEntity.py
@@ -5,6 +5,8 @@ from .permissions import getPermissions, newPermission, transferOwnership
 
 
 class PrimaryEntity(Entity):
+    __hasParentGroup__ = True
+
     def addComment(self, body, filepath=None, extraParams={}):
         """
         Add a comment and/or file to a Labstep Entity.

--- a/labstep/resource.py
+++ b/labstep/resource.py
@@ -5,7 +5,7 @@ from .primaryEntity import PrimaryEntity
 from .entity import getEntity, getEntities, newEntity, editEntity
 from .helpers import getTime
 from .metadata import addMetadataTo, getMetadata
-from .resourceItem import getResourceItems, newResourceItem
+from .resourceItem import getResourceItems, newResourceItem, ResourceItem
 from .orderRequest import newOrderRequest
 
 
@@ -104,7 +104,7 @@ def editResource(resource, name=None, deleted_at=None,
         An object representing the edited Resource.
     """
     params = {'name': name,
-              'resource_category_id': resource_category_id,
+              'template_id': resource_category_id,
               'deleted_at': deleted_at,
               **extraParams}
     return editEntity(resource, params)
@@ -350,3 +350,6 @@ class Resource(PrimaryEntity):
                                quantity_unit=quantity_unit,
                                resource_location_id=resource_location_id,
                                extraParams=extraParams)
+
+    def getResourceItemTemplate(self):
+        return ResourceItem(self.resource_item_template, self.__user__)

--- a/labstep/resource.py
+++ b/labstep/resource.py
@@ -7,6 +7,7 @@ from .helpers import getTime
 from .metadata import addMetadataTo, getMetadata
 from .resourceItem import getResourceItems, newResourceItem, ResourceItem
 from .orderRequest import newOrderRequest
+from .resourceCategory import getResourceCategory
 
 
 def getResource(user, resource_id):
@@ -224,6 +225,34 @@ class Resource(PrimaryEntity):
         """
         return getMetadata(self)
 
+    def getResourceCategory(self):
+        """
+        Get the ResourceCategory of the Resource.
+
+        Parameters
+        ----------
+        resource_category_id (int)
+            The id of :class:`~labstep.resourceCategory.ResourceCategory`
+            to set for
+            the Resource.
+
+        Returns
+        -------
+        :class:`~labstep.resourceCategory.ResourceCategory`
+            An object representing the Resource Category on Labstep.
+
+        Example
+        -------
+        ::
+
+            # Get a Resource
+            resource = user.getResource(170)
+
+            # Get the Resource Category of the resource
+            resourceCategory = resource.getResourceCategory()
+        """
+        return getResourceCategory(self.template['id'])
+
     def setResourceCategory(self, resource_category_id, extraParams={}):
         """
         Add a Labstep ResourceCategory to a Resource.
@@ -351,5 +380,71 @@ class Resource(PrimaryEntity):
                                resource_location_id=resource_location_id,
                                extraParams=extraParams)
 
-    def getResourceItemTemplate(self):
+    def getItemTemplate(self):
+        '''
+        Get the template used for initialising new items of the resource.
+        Returns
+        -------
+        :class:`~labstep.resourceItem.ResourceItem`
+            An object representing a ResourceItem on Labstep.
+
+        Example
+        -------
+        ::
+
+            my_resource = user.getResource(17000)
+            itemTemplate = my_resource.getItemTemplate()
+
+            itemTemplate.addMetadata('Expiry Date')
+
+        '''
+        if self.resource_item_template is None:
+            return None
+
         return ResourceItem(self.resource_item_template, self.__user__)
+
+    def enableCustomItemTemplate(self):
+        '''
+        Enable a custom item template for this resource.
+        If disabled the template for the Resource Category will be used.
+
+        Returns
+        -------
+        :class:`~labstep.resourceItem.ResourceItem`
+            An object representing a ResourceItem on Labstep.
+
+        Example
+        -------
+        ::
+
+            my_resource = user.getResource(17000)
+            my_resource.enableCustomItemTemplate()
+
+            itemTemplate = my_resource.getItemTemplate()
+
+            itemTemplate.addMetadata('Expiry Date')
+
+        '''
+        if self.resource_item_template is None:
+            self.newItem(extraParams={'is_template': True})
+        else:
+            self.getItemTemplate().edit(extraParams={'deleted_at': None})
+
+    def disableCustomItemTemplate(self):
+        '''
+        Disable custom item template for this resource.
+        If disabled the template for the Resource Category will be used.
+
+        Returns
+        -------
+        :class:`~labstep.resourceItem.ResourceItem`
+            An object representing a ResourceItem on Labstep.
+
+        Example
+        -------
+        ::
+
+            my_resource = user.getResource(17000)
+            my_resource.disableCustomItemTemplate()
+        '''
+        self.getItemTemplate().delete()

--- a/labstep/resourceCategory.py
+++ b/labstep/resourceCategory.py
@@ -156,10 +156,76 @@ class ResourceCategory(PrimaryEntity):
         return editResourceCategory(self, deleted_at=getTime())
 
     def getResourceTemplate(self):
+        '''
+        Returns the metadata template for resources of this category.
+
+        Example
+        -------
+        ::
+
+            my_resource_category = user.getResourceCategory(17000)
+            resourceTemplate = my_resource_category.getResourceTemplate()
+
+            resourceTemplate.getMetadata()
+            resourceTemplate.addMetadata('Vendor')
+        '''
         return ResourceTemplate(self.__data__, self.__user__)
 
-    def getResourceItemTemplate(self):
+    def getItemTemplate(self):
+        '''
+        Returns the item template for resources of this category.
+
+        Example
+        -------
+        ::
+
+            my_resource_category = user.getResourceCategory(17000)
+            itemTemplate = my_resource_category.getItemTemplate()
+
+            itemTemplate.getMetadata()
+            itemTemplate.addMetadata('Vendor')
+        '''
         return ResourceItem(self.resource_item_template, self.__user__)
+
+    def enableItemTemplate(self):
+        '''
+        Enable an item template for this resource category.
+        This template will be used to initialise new items for resources in this category, unless the resource has it's own custom template.
+
+        Returns
+        -------
+        :class:`~labstep.resourceItem.ResourceItem`
+            An object representing a ResourceItem on Labstep.
+
+        Example
+        -------
+        ::
+
+            my_resource = user.getResource(17000)
+            my_resource.enableCustomItemTemplate()
+
+            itemTemplate = my_resource.getItemTemplate()
+
+            itemTemplate.addMetadata('Expiry Date')
+
+        '''
+        if self.resource_item_template is None:
+            self.newItem(extraParams={'is_template': True})
+        else:
+            self.getItemTemplate().edit(extraParams={'deleted_at': None})
+
+    def disableItemTemplate(self):
+        '''
+        Disable the item template for this resource category.
+
+        Example
+        -------
+        ::
+
+            my_resource = user.getResource(17000)
+            my_resource.disableCustomItemTemplate()
+        '''
+        self.getItemTemplate().delete(extraParams={'deleted_at': None})
 
 
 class ResourceTemplate(Entity):

--- a/labstep/resourceCategory.py
+++ b/labstep/resourceCategory.py
@@ -3,9 +3,10 @@
 # pylama:ignore=E501
 
 from .primaryEntity import PrimaryEntity
-from .entity import getEntity, getEntities, newEntity, editEntity
+from .entity import getEntity, getEntities, newEntity, editEntity, Entity
 from .helpers import getTime
 from .metadata import addMetadataTo, getMetadata
+from .resourceItem import ResourceItem
 
 
 def getResourceCategory(user, resourceCategory_id):
@@ -53,7 +54,7 @@ def getResourceCategorys(user, count=100, search_query=None, tag_id=None,
     """
     filterParams = {'search_query': search_query,
                     'tag_id': tag_id}
-    params = {**filterParams, **extraParams}
+    params = {**filterParams, **extraParams, 'is_template': True}
     return getEntities(user, ResourceCategory, count, params)
 
 
@@ -74,7 +75,7 @@ def newResourceCategory(user, name, extraParams={}):
     ResourceCategory
         An object representing the new Labstep ResourceCategory.
     """
-    params = {'name': name, **extraParams}
+    params = {'name': name, **extraParams, 'is_template': True}
     return newEntity(user, ResourceCategory, params)
 
 
@@ -116,7 +117,7 @@ class ResourceCategory(PrimaryEntity):
         print(my_resource_category.name)
         print(my_resource_category.id)
     """
-    __entityName__ = 'resource-category'
+    __entityName__ = 'resource'
 
     def edit(self, name=None, extraParams={}):
         """
@@ -154,12 +155,22 @@ class ResourceCategory(PrimaryEntity):
         """
         return editResourceCategory(self, deleted_at=getTime())
 
+    def getResourceTemplate(self):
+        return ResourceTemplate(self.__data__, self.__user__)
+
+    def getResourceItemTemplate(self):
+        return ResourceItem(self.resource_item_template, self.__user__)
+
+
+class ResourceTemplate(Entity):
+    __entityName__ = 'resource'
+
     def addMetadata(self, fieldName, fieldType="default",
                     value=None, date=None,
                     number=None, unit=None,
                     extraParams={}):
         """
-        Add Metadata to a Resource Category.
+        Add Metadata to the Resource Template.
 
         Parameters
         ----------
@@ -196,7 +207,7 @@ class ResourceCategory(PrimaryEntity):
 
     def getMetadata(self):
         """
-        Retrieve the Metadata of a Labstep Resource.
+        Retrieve the Metadata of the Resource Template.
 
         Returns
         -------

--- a/labstep/resourceItem.py
+++ b/labstep/resourceItem.py
@@ -168,7 +168,7 @@ class ResourceItem(Entity):
         name (str)
             The new name of the ResourceItem.
         availability (str)
-            The status of the OrderRequest. Options are:
+            The availability of the ResourceItem. Options are:
             "available" and "unavailable".
         quantity_amount (float)
             The quantity of the ResourceItem.

--- a/labstep/resourceLocation.py
+++ b/labstep/resourceLocation.py
@@ -117,6 +117,7 @@ class ResourceLocation(Entity):
         print(my_resource_location.id)
     """
     __entityName__ = 'resource-location'
+    __hasParentGroup__ = True
 
     def edit(self, name=None, extraParams={}):
         """

--- a/labstep/tag.py
+++ b/labstep/tag.py
@@ -181,6 +181,7 @@ class Tag(Entity):
         print(my_tag.id)
     """
     __entityName__ = 'tag'
+    __hasParentGroup__ = True
 
     def edit(self, name=None, extraParams={}):
         """

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,9 @@
 import labstep
+import os
 
-user = labstep.login('apitest@labstep.com', 'apitestpass')
+TESTING_KEY = os.getenv('TESTING_KEY')
+
+user = labstep.authenticate('apitest@labstep.com', TESTING_KEY)
 
 tableData = {
     "rowCount": 6,

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -52,9 +52,9 @@ class TestResource:
     def test_setResourceCategory(self):
         my_resourceCategory = user.getResourceCategorys()[0]
         entity.setResourceCategory(my_resourceCategory.id)
-        entity.update()
-        assert entity.resource_category is not None, \
-            'FAILED TO ADD METADATA'
+        resourceCategory = entity.getResourceCategory()
+        assert resourceCategory is not None, \
+            'FAILED TO SET RESOURCE CATEGORY'
 
     def test_newOrderRequest(self):
         result = entity.newOrderRequest()
@@ -70,3 +70,13 @@ class TestResource:
         result = entity.getItems()
         assert result[0].id, \
             'FAILED TO GET ITEMS'
+
+    def test_enableItemTemplate(self):
+        entity.enableItemTemplate()
+        itemTemplate = entity.getItemTemplate()
+        assert itemTemplate.deleted_at is not None
+
+    def test_disableItemTemplate(self):
+        entity.disableItemTemplate()
+        itemTemplate = entity.getItemTemplate()
+        assert itemTemplate.deleted_at is None

--- a/tests/test_resource_category.py
+++ b/tests/test_resource_category.py
@@ -20,7 +20,8 @@ class TestResourceCategory:
             'FAILED TO DELETE RESOURCE CATEGORY'
 
     def test_addComment(self):
-        result = entity.addComment(testString, './tests/test_resource_category.py')
+        result = entity.addComment(
+            testString, './tests/test_resource_category.py')
         assert result is not None, \
             'FAILED TO ADD COMMENT AND FILE'
 
@@ -41,12 +42,22 @@ class TestResourceCategory:
 
     def test_addMetadata(self):
         new_resource_category = user.newResourceCategory(testString)
-        result = new_resource_category.addMetadata(fieldName=testString,
-                                                   value=testString)
+        result = new_resource_category.getResourceTemplate().addMetadata(fieldName=testString,
+                                                                         value=testString)
         assert result.label == testString, \
             'FAILED TO ADD METADATA'
 
     def test_getMetadata(self):
-        result = entity.getMetadata()
+        result = entity.getResourceTemplate().getMetadata()
         assert result[0].id is not None, \
             'FAILED TO GET METADATA'
+
+    def test_enableItemTemplate(self):
+        entity.enableItemTemplate()
+        itemTemplate = entity.getItemTemplate()
+        assert itemTemplate.deleted_at is not None
+
+    def test_disableItemTemplate(self):
+        entity.disableItemTemplate()
+        itemTemplate = entity.getItemTemplate()
+        assert itemTemplate.deleted_at is None


### PR DESCRIPTION
- Resource Categories as resources with `is_template = True`
- Add method getItemTemplate, enableItemTemplate and disableItemTemplate to Resource class and ResourceCategory class
- Only send `group_id` for primary entities